### PR TITLE
CA comments for paperless(-ng)

### DIFF
--- a/Moderation.json
+++ b/Moderation.json
@@ -871,5 +871,8 @@
   },
   "selfhosters/paperless-ng": {
     "CAComment": "This application requires redis to be installed."
+  },
+  "selfhosters/paperless": {
+    "CAComment": "While still functional, the author recommends to migrate to paperless-ng."
   }
 } 

--- a/Moderation.json
+++ b/Moderation.json
@@ -868,5 +868,8 @@
   "slrgde/glftpd": {
     "Deprecated": true,
     "ModeratorComment": "Deprecated by the author"
+  },
+  "selfhosters/paperless-ng": {
+    "CAComment": "This application requires redis to be installed."
   }
 } 


### PR DESCRIPTION
This pull requests adds:

- a CA comment for paperless-ng indicating that a redis container is required
- a CA comment for paperless encouraging users to use paperless-ng

The original paperless project got archived in favor of paperless-ng (see [here](https://github.com/the-paperless-project/paperless#important-news-about-the-future-of-this-project)). The old paperless still exists and is functional though. In the future I plain to remove the paperless template from the CA. But for now I want to give the users time to migrate and also make sure new installs happen for paperless-ng instead of paperless.

Let me know if I can help to get this merged.

