### PR TITLE
Duplicate template has been removed

### DIFF
--- a/Repositories.json
+++ b/Repositories.json
@@ -591,8 +591,7 @@
       "hotio/plex": true,
       "hotio/cloudflare-ddns": true,
       "hotio/hddtemp2influxdb": true,
-      "koenkk/zigbee2mqtt": true,
-      "nwithan8/tauticord:latest": true
+      "koenkk/zigbee2mqtt": true
     }
   },
   {


### PR DESCRIPTION
Tauticord has been removed from the SelfHosters repository and now only exists in `grtgbln`'s repo.