### PR TITLE
Add emaspa's Repository (WireView Pro II plugin)

### DIFF
--- a/Repositories.json
+++ b/Repositories.json
@@ -1,4088 +1,4090 @@
 [
-  {
-    "url": "https://github.com/snuffomega/docker_unraid_templates",
-    "name": "snuffomega's Repository",
-    "profile": "https://forums.unraid.net/profile/258583-snuffomega/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/laurensguijt/unraid-templates",
-    "name": "Laurensguijt's Repository",
-    "profile": "https://forums.unraid.net/profile/254983-laurensguijt/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/neur0map/deskmon-unraid-templates",
-    "name": "Neur0map's Repository",
-    "profile": "https://forums.unraid.net/profile/294130-neur0map/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/mayo-248/unraid-templates",
-    "name": "Mayo_248's Repository",
-    "profile": "https://forums.unraid.net/profile/175387-mayo_248/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/davidjkling/unraid-templates",
-    "name": "Kling's Repository",
-    "profile": "https://forums.unraid.net/profile/293102-kling/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/gibz104/SpoolmanSync",
-    "name": "gibz104's Repository",
-    "profile": "https://forums.unraid.net/profile/293978-gibz104/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/ghzgod/signal-notification-unraid",
-    "name": "ghzgod11's Repository",
-    "profile": "https://forums.unraid.net/profile/293977-ghzgod11/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/caddickzac/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/293796-zcaddick/",
-    "name": "zcaddick's Repository",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/TorBox-App/unraid-templates",
-    "name": "Wamy's Repository",
-    "profile": "https://forums.unraid.net/profile/247536-wamy/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/Saetron/unRAID-CA-templates",
-    "name": "saetron's Repository",
-    "profile": "https://forums.unraid.net/profile/290584-saetron/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/johnpwhite/unraid-community-applications-index",
-    "name": "johner's Repository",
-    "profile": "https://forums.unraid.net/profile/5686-johner/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/kikootwo/ReadMeABook",
-    "name": "ReadMeABook's Repository",
-    "profile": "https://forums.unraid.net/profile/293929-kikootwo/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/mccann6/unraid-templates/",
-    "name": "mccann6's Repository",
-    "profile": "https://forums.unraid.net/profile/293805-mccann6/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/Petelombardo/unraid-templates",
-    "name": "Pete L's Repository",
-    "profile": "https://forums.unraid.net/profile/293917-pete-l/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/medzin/docker-templates",
-    "name": "medzin's Repository",
-    "profile": "https://forums.unraid.net/profile/293048-medzin/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/MrCorehh/unraid-templates",
-    "name": "MrCorehh's Repository",
-    "profile": "https://forums.unraid.net/profile/293911-mrcorehh/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/Watso4183/Unraid",
-    "name": "AcmePluto's Repository",
-    "profile": "https://forums.unraid.net/profile/293586-acmepluto/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/AradD7/lightarr-template-files",
-    "name": "Arad's Repository",
-    "profile": "https://forums.unraid.net/profile/293896-arad",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/liorbass/tandarr-unraid-templates",
-    "name": "LioirBass' Repository",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/dervish666/unraid-templates",
-    "name": "dervish's Repository",
-    "profile": "https://forums.unraid.net/profile/179627-dervish/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/davemachado/unraid-templates",
-    "name": "drm's Repository",
-    "profile": "https://forums.unraid.net/profile/291782-drm8/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/softerfish/seekandwatch",
-    "name": "tenletter's Repository",
-    "profile": "https://forums.unraid.net/profile/283725-tenletters/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/fccview/unraid-templates",
-    "name": "fccview's Repository",
-    "profile": "https://forums.unraid.net/profile/293085-fccview/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/jessielw/unraid-templates",
-    "name":"Jessielw's Repository",
-    "profile": "https://forums.unraid.net/profile/201686-jessielw/",
-    "communication": "forum"
-  },
-  {
-    "url": "https://github.com/nebula-codes/hytale_server_manager", 
-    "name": "Nebula's Repository",
-    "profile": "https://forums.unraid.net/profile/293434-nebulacodes/",
-    "communication": "discord"
-  },
-  {
-    "url": "https://github.com/CaptainPimpJr/Unraid-Community-Applications",
-    "name": "CaptainPimpJr's Repository",
-    "profile": "https://forums.unraid.net/profile/271177-cptpimpjunior/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/Maikboarder/Playerr",
-    "name": "Maikboarder's Repository",
-    "profile": "https://forums.unraid.net/profile/293293-maikboarder/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/gthrift/gthrift-unraid-ca",
-    "name": "gthrift's Repository",
-    "profile": "https://forums.unraid.net/profile/293215-gthrift/",
-    "communication": "email"
-  },
-  {
-    "url": "https://github.com/MattyStacks/docker-templates",
-    "name": "MattyStacks's Repository",
-    "profile": "https://forums.unraid.net/profile/9036-mattystacks/",
-    "communication": "discord"
-  },
-    {
-        "url": "https://github.com/Yusseiin/unraid-templates",
-        "name": "Yusseiin's Repository",
-        "profile": "https://forums.unraid.net/profile/279816-yusseiin/",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/cabi24/notenregal",
-        "name": "cabi24's Repository",
-        "communication": "email"
-    },
-    
-    {
-        "url": "https://github.com/schartrand77/mkw2",
-        "name": "schartrand77's Repository",
-        "profile": "https://forums.unraid.net/profile/180557-schartrand77/",
-        "communication": "discord"
-    },
-    {
-        "name": "snoopy86's Repository",
-        "url":  "https://github.com/devdems/unraid",
-        "forum":  "http://lime-technology.com/forum/index.php?topic=43610.0",
-        "profile": "https://forums.unraid.net/profile/26537-snoopy86/"
-    },
-    {
-        "url": "https://github.com/orangecoding/fredy-unraid-template",
-        "name": "Orangecoding's Repository",
-        "profile": "https://forums.unraid.net/profile/292517-orangecoding/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/jandrop/file_core_api_unraid",
-        "name": "jandrop's Repository",
-        "profile": "https://forums.unraid.net/profile/111434-jandrop/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/connorgallopo/tracearr-unraid-template",
-        "name": "Gallapagos' Repository",
-        "profile": "https://forums.unraid.net/profile/281348-gallapagos/",
-        "communication": "discord"
-    },
-    {
-        "url":"https://github.com/Indemnity83/always-bring-a-gift",
-        "name": "Indemnity83's Repository",
-        "profile": "https://forums.unraid.net/profile/83781-indemnity83/",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/keenaanee/CinemaStatus",
-        "name": "Keenaanee's Repository",
-        "profile": "https://forums.unraid.net/profile/271535-keenaanee/",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/JFLXCLOUD/NeXroll",
-        "name": "NeXroll's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/jlightner86/jellylooter",
-        "name": "ThePizzaNinja86's Repository",
-        "profile": "https://forums.unraid.net/profile/287631-thepizzaninja86/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/anym001/unraid-docker-templates",
-        "name": "Anym001's Repository",
-        "profile": "https://forums.unraid.net/profile/119296-anym001/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/vincentmakes/cv-manager",
-        "name": "vincentmakes' Repository",
-        "profile": "https://forums.unraid.net/profile/292228-vincentmakes/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/kurrier-org/kurrier",
-        "name": "debuggy12's Repository",
-        "profile": "https://forums.unraid.net/profile/292187-debuggy12/",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/WuSiYu/unraid-ca-xml/",
-        "name": "Wu23333's Repository",
-        "profile": "https://forums.unraid.net/profile/175574-wu23333/",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/murtaza-nasir/speakr-unraid",
-        "name": "learnedmachine's Repository",
-        "profile": "https://github.com/murtaza-nasir/speakr-unraid",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/sftpmalin/Media-Remote-Convert",
-        "name": "SftpMalin FFmpeg's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/DevlinDelFuego/unraid-templates",
-        "name": "DevlinDelFuego's Repository",
-        "profile": "https://forums.unraid.net/profile/287879-devlindelfuego/",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/ruaan-deysel/unraid-management-agent",
-        "name": "PanicMechanic00's Repository",
-        "profile": "https://forums.unraid.net/profile/98076-panicmechanic007/",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/theodorecharles/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103598-paloooz/",
-        "name": "paloooz's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/m3ue/m3u-editor",
-        "profile": "https://forums.unraid.net/profile/292018-shparkison/",
-        "name": "shparikson's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/T4s3rF4c3/macreplay_v2",
-        "profile": "https://forums.unraid.net/profile/150938-t4s3rf4c3/",
-        "name": "T4s3rF4c3's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/carrotwaxr/peek-stash-browser",
-        "profile": "https://forums.unraid.net/profile/291876-carrot-waxxr/",
-        "name": "Carrot Waxxr's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/NickBootOne/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/93263-nickboot/",
-        "name": "nickboot's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/untraceablez/unraid-apps/",
-        "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
-        "name": "untraceablez's Repository",
-        "communication": "discord"
-    },
-   
-    {
-        "url": "https://github.com/kroeberd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/291694-sarcasm/",
-        "name": "sarcasm's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/BabaBooey84/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/7743-uderzo/",
-        "name": "Uderzo's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/mbirnbach/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/291521-mbirnbach/",
-        "name": "mbirnbach's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/N85UK/UNRAID_APP",
-        "profile": "https://forums.unraid.net/profile/109185-paulmccannn85uk/",
-        "name": "N85UK's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/cajuncoding/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/134398-cajuncoding/",
-        "name": "CajunCoding's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/buxxdev/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/291279-mbxy/",
-        "name": "buxxdev's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/netpersona/popcorn-unraid",
-        "profile": "https://forums.unraid.net/profile/234637-smackmybones/",
-        "name": "Netpersona's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/dopeytree/Unraid-templates",
-        "profile": "https://forums.unraid.net/profile/183052-dopeytree/",
-        "name": "dopeytree's Repository",
-        "communication": "forum"
-    },
-    {
-    "name": "Dynamix Plugin Repository",
-    "url":  "https://github.com/unraid/dynamix-plugins-xml",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=36543.0",
-    "profile": "https://forums.unraid.net/profile/2736-bonienl/"
-  },
-  {
-    "name": "Dynamix Repository",
-    "url":  "https://github.com/bergware/dynamix-plugins",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=36543.0",
-    "profile": "https://forums.unraid.net/profile/2736-bonienl/",
-    "hideFromCA": {
-        "https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.encryption.key.plg": true,
-        "https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.factory.reset.plg": true,
-        "https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.safe.mode.plg": true,
-        "https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.share.floor.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.active.streams.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.cache.dirs.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.date.time.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.day.night.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.file.integrity.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.file.manager.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.local.master.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.password.validator.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.s3.sleep.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.schedules.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.scsi.devices.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.ssd.trim.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.stop.shell.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.autofan.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.buttons.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.info.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.stats.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.temp.plg": true,
-        "https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.wireguard.plg": true,
-        "https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.encryption.key.plg": true,
-        "https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.factory.reset.plg": true,
-        "https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.safe.mode.plg": true,
-        "https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.share.floor.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.active.streams.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.cache.dirs.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.date.time.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.day.night.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.file.integrity.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.file.manager.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.local.master.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.password.validator.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.s3.sleep.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.schedules.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.scsi.devices.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.ssd.trim.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.stop.shell.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.autofan.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.buttons.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.info.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.stats.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.temp.plg": true,
-        "https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.wireguard.plg": true
- 
-      }
-    },
-    {
-        "url": "https://github.com/rschuiling/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/261141-emphyrio/",
-        "name": "Emphyrio's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/bigsing/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/7676-bigsing/",
-        "name": "bigsing's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/xxBeanSproutxx/unraid-docling-ca",
-        "profile": "https://forums.unraid.net/profile/288925-bean_sprout/",
-        "name": "xxBeanSproutxx's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Shaneee/system-monitor",
-        "profile": "https://forums.unraid.net/profile/290974-shaneee92/",
-        "name": "Shaneee's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Pa7rickStar/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/288616-pa7rickstar/",
-        "name": "Pa7ricstar's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/afairgiant/MediKeep_unraid",
-        "profile": "https://forums.unraid.net/profile/116260-afairgiant/",
-        "name": "afairgiant's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/thedinz/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145818-thedinz/",
-        "name": "thedinz' Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/framedr0p/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290788-framedr0p/",
-        "name": "framdr0p's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Skylinar/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/109199-skylinar/",
-        "name": "Skylinar's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/undead-reaper/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
-        "name": "Undead Reaper's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/egnerdata/unraid-docker-template-papra",
-        "profile": "https://forums.unraid.net/profile/274607-egnerdata/",
-        "name": "Egnerdata's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/RoBro92/fanbridge-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290531-robro92/",
-        "name": "RoBro92's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/jjermany/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/288757-jermcee/",
-        "name": "jermcee's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/mlapaglia/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/100043-mlapaglia/",
-        "name": "mlapaglia's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/slamanna212/UnraidTemplates",
-        "profile": "https://forums.unraid.net/profile/106550-slamanna212/",
-        "name": "slamanna212's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/drewzh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/266696-abreast-statesman5405/",
-        "name": "abreast-statesman5405's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/MitchellThompkins/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285040-not_a_real_human/",
-        "name": "not_a_real_human's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/benjaminRoberts01375/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290281-preposterous/",
-        "name": "Preposterous' Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/GEngines/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/290261-bmetpally/",
-        "name": "GEngines' Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/BryanGoble/docker-templates",
-        "profile": "https://forums.unraid.net/profile/290235-bgubs/",
-        "name": "bgubs' Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/cleao01/UnraidDockerTemplates",
-        "profile": "https://forums.unraid.net/profile/123530-cab%C3%A9/",
-        "name": "Cabé's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Twingate-Community/unraid-template",
-        "profile": "https://forums.unraid.net/profile/289418-twingate-andrewb/",
-        "name": "Twingate Community's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/rohit-purandare/ShelfBridge-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283015-rpurandare/",
-        "name": "rpurandare's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/T-Eberle/unraid-community-apps",
-        "profile": "https://forums.unraid.net/profile/289970-tommy_e/",
-        "name": "Tommy_E's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/cameron581/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/253440-cameron581/",
-        "name": "Cameron581's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Zuerrex/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/234570-zuerrex/",
-        "name": "zuerrex's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/secretlycarl/onboarderr-unraid",
-        "profile": "https://forums.unraid.net/profile/289747-secretlycarl/",
-        "name": "SecretlyCarl's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/tajniak81/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/98215-tajniak81/",
-        "name": "Tajniak81's Repository",
-        "communication": "forum "
-    },
-    {
-        "url": "https://github.com/catapultcase/Unraid_CommunityApplications",
-        "profile": "https://forums.unraid.net/profile/83669-rusty6285/",
-        "name": "Rusty6285's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Cleanuparr/unraid",
-        "profile": "https://forums.unraid.net/profile/282380-flamin/",
-        "name": "Flamin's Repository",
-        "communication:": "discord"
-    },
-    {
-        "url": "https://github.com/OctoEverywhere/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/289064-quinninator/",
-        "name": "Quinninator's Repository",
-        "communication:": "email"
-    },
-    {
-        "url": "https://github.com/ObviousViking/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/114882-obviousviking/",
-        "name": "ObviousViking's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/jo-sobo/scriptlogs-unraid-plugin",
-        "profile": "https://forums.unraid.net/profile/120452-magnum308/",
-        "name": "Magnum.308's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/warwickschroeder/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/103842-syknight/",
-        "name": "Syknight's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/soitora/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/282682-soitora/",
-        "name": "Soitora's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/gameyfin/unraid",
-        "profile": "https://forums.unraid.net/profile/249165-grimsi/",
-        "name": "grimsi's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/CordlessWool/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/289062-cordlesswool/",
-        "name": "CordlessWool's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/tophat17/jelly-request",
-        "profile": "https://forums.unraid.net/profile/172432-tophat17/",
-        "name": "TopHat17's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/acidrs03/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125556-acidrs/",
-        "name": "Acidrs' Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/ajb3932/unraid-ca-templates",
-        "profile": "https://forums.unraid.net/profile/276974-ajb3932/",
-        "name": "ajb3932's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/RobertCajun/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285092-robertcajun/",
-        "name": "RobertCajun's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/alyssaholland99/unraid-immich-tiktok-remover",
-        "profile": "https://forums.unraid.net/profile/289132-alyssaholland/",
-        "name": "AlyssaHolland's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/strike84/DiskSpaceManagement-template",
-        "profile": "https://forums.unraid.net/profile/63311-strike/",
-        "name": "strike's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/jcofer555/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/135547-jcofer555/",
-        "name": "jcofer555's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/ck9393/fanctrlplus",
-        "profile": "https://forums.unraid.net/profile/242702-ckchong/",
-        "name": "ck9393's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/DearTanker/Unraid-Docker-Template",
-        "profile": "https://forums.unraid.net/profile/98483-deartanker/",
-        "name": "DearTanker's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Gill-Bates/unraid-app-templates",
-        "profile": "https://forums.unraid.net/profile/288881-gillbates/",
-        "name": "GillBates' Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/NickBorgers/unraid-apps",
-        "profile": "https://forums.unraid.net/profile/69750-nickborgers/",
-        "name": "Nick Borgers' Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/Kurotaku-sama/Unraid-Plugins-Repository",
-        "profile": "https://forums.unraid.net/profile/277881-kurotaku/",
-        "name": "Kurotaku's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/Cirx08/Unraid",
-        "profile": "https://forums.unraid.net/profile/288718-cirx08/",
-        "name": "Cirx08's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/yannisalexiou/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283014-yannisalexiou/",
-        "name": "Docked by Yannis' Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/silkyclouds/PMDA_unraid_xml",
-        "profile": "https://forums.unraid.net/profile/170800-meaning/",
-        "name": "PMDA's Repository",
-        "communication": "discord"
-    },
-    {
-        "url": "https://github.com/mediux-team/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/125333-mmoosem/",
-        "name": "Mediux-Team's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/misterjtc/docker-templates",
-        "profile": "https://forums.unraid.net/profile/68425-misterjtc/",
-        "name": "Misterjtc's Repository",
-        "communication": "forum"
-    },
-    {
-        "url": "https://github.com/alexycodes/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/288438-alexycodes/",
-        "name": "Alexy's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/desertwitch/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/115350-rysz/",
-        "name": "Rysz's Repository"
-    },
-    {
-        "url": "https://github.com/Michuelnik/docker-mediathekview-web",
-        "profile": "https://forums.unraid.net/profile/153213-revan335/",
-        "name": "Reven335's Repository"
-    },
-    {
-        "url": "https://github.com/Bovive/unraid-docker-templates",
-        "profile":"https://forums.unraid.net/profile/259292-bovive/",
-        "name": "Bovive's Repository"
-    },
-    {
-        "url": "https://github.com/AnimaI/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126104-d0ooo/",
-        "name": "D0ooo's Repository"
-    },
-    {
-        "url": "https://github.com/mackid1993/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/74622-mackid1993/",
-        "name": "Mackid1993's Repository"
-    },
-    {
-        "url": "https://github.com/celsian/unraid_templates",
-        "profile": "https://forums.unraid.net/profile/120837-celsian/",
-        "name": "Celsian's Repository"
-    },
-    {
-        "url": "https://github.com/EddCase/unRAID_Templates",
-        "profile": "https://forums.unraid.net/profile/10833-eddcase/",
-        "name": "EddCase's Repository"
-    },
-    {
-        "url": "https://github.com/googleg/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282598-googleg/",
-        "name": "googleg's Repository"
-    },
-    {
-        "url": "https://github.com/AnimaI/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/126104-d0ooo/",
-        "name": "d0ooo's Repository"
-    },
-    {
-        "url": "https://github.com/TorBox-App/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/247536-wamy/",
-        "name": "Wamy's Repository"
-    },
-    {
-        "url": "https://github.com/dkeners/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287661-dkeners/",
-        "name": "dkeners' Repository"
-    },
-    {
-        "url": "https://github.com/jamcalli/pulsarr-unraid-templates",
-        "profile": "https://forums.unraid.net/profile/286940-sp00ks/",
-        "name": "sp00ks' Repository"
-    },
-    {
-        "url": "https://github.com/itsnotashley/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/287054-itsnotashley/",
-        "name": "itsnotashley's Repository"
-    },
-    {
-        "url": "https://github.com/andrejwithj/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/168139-fancyshmancy/",
-        "name": "fancyshmancy's Repository"
-    },
-    {
-        "url": "https://github.com/VladoPortos/vladoportos-unraid-xml",
-        "profile": "https://forums.unraid.net/profile/103082-vladoportos/",
-        "name": "VladoPortos' Repository"
-    },
-    {
-        "url": "https://github.com/MorgothRB/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/280956-morgoth/",
-        "name": "Morgoth's Repository"
-    },
-    {
-        "url": "https://github.com/jl94x4/ColleXions",
-        "profile": "https://forums.unraid.net/profile/270097-thatja/",
-        "name": "thatja's Repository"
-    },
-    {
-        "url": "https://github.com/theweebcoders/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/146571-tim000x3/",
-        "name": "tim000x3's Repository"
-    },
-    {
-        "url": "https://github.com/glls/Docker-Templates-Unraid",
-        "profile": "https://forums.unraid.net/profile/272335-glls/",
-        "name": "glls' Repository"
-    },
-    {
-        "url": "https://github.com/damongolding/immich-kiosk-unraid",
-        "profile": "https://forums.unraid.net/profile/285555-damongolding/",
-        "name": "DamonGolding's Repository"
-    },
-    {
-        "url": "https://github.com/eibex/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/268287-eibe/",
-        "name": "Eibe's Repository"
-    },
-    {
-        "url": "https://github.com/JZomDev/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/159615-zguilt/",
-        "name": "zguilt's Repository"
-    },
-    {
-        "url": "https://github.com/justjoseorg/Unraid-Intel_Ollama",
-        "profile": "https://forums.unraid.net/profile/261082-possessive-small6053/",
-        "name": "progressive-small6053's Repository"
-    },
-    {
-        "url": "https://github.com/SCUR0/Unraid_Docker_Locust",
-        "profile": "https://forums.unraid.net/profile/274107-scuro/",
-        "name": "Scuro's Repository"
-    },
-    {
-        "url": "https://github.com/robotfishe/robotfishe-unraid-apps",
-        "profile": "https://forums.unraid.net/profile/204504-robotfishe/",
-        "name": "robotfishe's Repository"
-    },
-    {
-        "url": "https://github.com/Eksistenze/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/153955-eksistenze/",
-        "name": "Eksistenze's Repository"
-    },
-    {
-        "url": "https://github.com/xshatterx/Seraphys",
-        "profile": "https://forums.unraid.net/profile/275245-seraphys/",
-        "name": "Seraphys' Repository"
-    },
-    {
-        "url": "https://github.com/stefan-matic/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/269247-fallen94/",
-        "name": "Fallen94's Repository"
-    },
-    {
-        "url": "http://github.com/RiDDiX/uraid-templates",
-        "profile": "https://forums.unraid.net/profile/123957-riddix/",
-        "name": "RiDDiX's Repository"
-    },
-    {
-        "url": "https://github.com/NicolasHaas/unraid-xml-templates",
-        "profile": "https://forums.unraid.net/profile/110262-twixii/",
-        "name": "Twixii's Repository"
-    },
-    {
-        "url": "https://github.com/guniv/unraid-ca-apps",
-        "profile": "https://forums.unraid.net/profile/178712-guniv/",
-        "name": "guniv's Repository"
-    },
-    {
-        "url": "https://github.com/RafaelCenzano/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/171730-cenzar/",
-        "name": "cenzar's Repository"
-    },
-    {
-        "url": "https://github.com/timespacedecay/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/121604-lostinspace/",
-        "name": "lostinspace's Repository"
-    },
-    {
-        "url": "https://github.com/mcreekmore/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/216090-mcreekmore/",
-        "name": "mcreekmore's Repository"
-    },
-    {
-        "url": "https://github.com/mash2k3/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/265722-mash2k3/",
-        "name": "mash2k3's Repository"
-    },
-    {
-        "url": "https://github.com/ctrlaltd1337ed/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/84709-ctrlaltd1337/",
-        "name": "ctrlaltd1337's Repository"
-    },
-    {
-        "url": "https://github.com/vwdewaal/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/145081-vannie78/",
-        "name": "vannie78's Repository"
-    },
-    {
-        "url": "https://github.com/TheMapledCog/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/168586-campu0999/",
-        "name": "campu0999's Repository"
-    },
-    {
-        "url": "https://github.com/error311/UNRAID_COMMUNITY_APPS",
-        "profile": "https://forums.unraid.net/profile/207982-error311/",
-        "name": "error311's Repository"
-    },
-    {
-        "url": "https://github.com/TheBinaryNinja/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/103361-iflip721/",
-        "name": "i.Flip721's Repository"
-    },
-    {
-        "url": "https://github.com/jterpstra1/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/92505-jterpstra/",
-        "name": "jterpstra's Repository"
-    },
-    {
-        "url": "https://github.com/Maitresinh/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/280760-logan23/",
-        "name": "logan23's Repository"
-    },
-    {
-        "url": "https://github.com/damongolding/immich-kiosk-unraid",
-        "profile": "https://forums.unraid.net/profile/285555-damongolding/",
-        "name": "DamonGolding's Repository"
-    },
-    {
-        "url": "https://github.com/oromis995/UnraidKoboldCpp",
-        "profile": "https://forums.unraid.net/profile/108450-oromis95/",
-        "name": "oromis95's Repository"
-    },
-    {
-        "url": "https://github.com/b3rrytech/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/11610-b3rrytech/",
-        "name": "b3rrytech's Repository"
-    },
-    {
-        "url": "https://github.com/olilanz/unraid-templates/",
-        "profile": "https://forums.unraid.net/profile/175858-boomshakalaka/",
-        "name": "boomshakala's Repository"
-    },
-    {
-        "url": "https://github.com/Krillsson/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285387-krillsson/",
-        "name": "Krillsson's Repository"
-    },
-    {
-        "url": "https://github.com/SnuK87/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/285383-snuk/",
-        "name": "Snuk's Repository"
-    },
-    {
-        "url": "https://github.com/crgodfrey/unraid-froggi",
-        "profile": "https://forums.unraid.net/profile/274467-monkeyss/",
-        "name": "monkeyss' Repository"
-    },
-    {
-        "url": "https://github.com/eulaly/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/99159-dealbakerjones/",
-        "name": "dealbakerjones' Repository"
-    },
-    {
-        "url": "https://github.com/clairekardas/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/269754-anna/",
-        "name": "anna's Repository"
-    },
-    {
-        "url": "https://github.com/XeXSolutions/unraid-stats",
-        "profile": "https://forums.unraid.net/profile/165045-xexsolutions/",
-        "name": "XeXSolutions' Repository"
-    },
-    {
-        "url": "https://github.com/Piratkopia13/unraid-buddybackup",
-        "profile": "https://forums.unraid.net/profile/158066-pirat/",
-        "name": "Pirat's Repository"
-    },
-    {
-        "url": "https://github.com/swiss01/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/96834-swiss01/",
-        "name": "swiss01's Repository"
-    },
-    {
-        "url": "https://github.com/cmoro-deusto/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284950-cmoro-gondor/",
-        "name": "cmoro-gondor's Repository"
-    },
-    {
-        "url": "https://github.com/sam10155/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/116626-sam10155/",
-        "name": "sam10155's Repository"
-    },
-    {
-        "url": "https://github.com/swiss01/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/96834-swiss01/",
-        "name": "swiss01's Repository"
-    },
-    {
-        "url": "https://github.com/ltdstudio/MoviePilot_unraid_CA",
-        "profile": "https://forums.unraid.net/profile/284198-doudou1234/",
-        "name": "doudou1234's Repository"
-    },
-    {
-        "url": "https://github.com/NSPManager/NSPanelManager",
-        "profile": "https://forums.unraid.net/profile/122183-sbeex/",
-        "name": "sbeex's Repository"
-    },
-    {
-        "url": "https://github.com/xshatterx/Seraphys",
-        "profile": "https://forums.unraid.net/profile/275245-seraphys/",
-        "name": "Seraphys' Repository"
-    },
-    {
-        "url": "https://github.com/JourneyDocker/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284186-journeyover/",
-        "name": "JourneyOver's Repository"
-    },
-    {
-        "url": "https://github.com/fejich/unRAID-plugins-templates",
-        "profile": "https://forums.unraid.net/profile/122412-fejich/",
-        "name": "fejich's Repository"
-    },
-    {
-        "url": "https://github.com/UnToobed/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/160182-unusmundus/",
-        "name": "UnusMundus' Repository"
-    },
-    {
-        "url": "https://github.com/fosrl/templates",
-        "profile": "https://forums.unraid.net/profile/96141-milo-schwartz/",
-        "name": "Fossorial's Repository",
-        "duplicated": {
-            "traefik:latest": true
-        }
-    },
-    {
-        "url": "https://github.com/jarvis2f/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/284045-jarvis2f/",
-        "name": "jarvis2f's Repository"
-    },
-    {
-        "url": "https://github.com/jjdenhertog/spotify-to-plex-unraid",
-        "profile": "https://forums.unraid.net/profile/283509-jjdenhertog/",
-        "name": "jjdenhertog's Repository"
-    },
-    {
-        "url": "https://github.com/bghizzy/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/268319-bg_hizzy/",
-        "name": "bg_hizzy's Repository"
-    },
-    {
-        "url": "https://github.com/Teknicallity/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/170368-teknicallity/",
-        "name": "Teknicallity's Repository"
-    },
-    {
-        "url": "https://github.com/smoores-dev/storyteller-unraid",
-        "profile": "https://forums.unraid.net/profile/144985-smoores/",
-        "name": "smoores' Repository"
-    },
-    {
-        "url": "https://github.com/kuroki-kael/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283413-tatseo/",
-        "name": "tatseo's Repository"
-    },
-    {
-        "url": "https://github.com/Mainfrezzer/UnRaid-Templates/",
-        "profile": "https://forums.unraid.net/profile/201895-mainfrezzer/",
-        "name": "Mainfrezzer's Repository"
-    },
-    {
-        "url":"https://github.com/Receipt-Wrangler/receipt-wrangler-unraid",
-        "profile": "https://forums.unraid.net/profile/268018-wrangler/",
-        "name": "wrangler's Repository"
-    },
-    {
-        "url": "https://github.com/TypingPenguin/docker-templates",
-        "profile": "https://forums.unraid.net/profile/283235-typingpenguin/",
-        "name": "TypingPenguin's Repository"
-    },
-    {
-        "url": "https://github.com/hhftechnology/unraid_app_templates",
-        "profile": "https://forums.unraid.net/profile/282959-hhftechnology/",
-        "name": "hhftechnology's Repository",
-        "duplicated": {
-            "donetick/donetick": true
-        }
-    },
-    {
-        "url": "https://github.com/undead-reaper/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
-        "name": "Dharam Soni's Repository"
-    },
-    {
-        "url": "https://github.com/masterjb/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/124596-human-126094/",
-        "name": "Human-126094's Repository"
-    },
-    {
-        "url": "https://github.com/jcesclapez/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/280038-darklesc/",
-        "name": "Darklesc's Repository"
-    },
-    {
-        "url": "https://github.com/carroarmato0/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/169872-carroarmato0/",
-        "name": "carroarmato0's Repository"
-    },
-    {
-        "url": "https://github.com/matda59/video-to-mp3-converter",
-        "profile": "https://forums.unraid.net/profile/119423-matda59/",
-        "name": "matda59's Repository"
-    },
-    {
-        "url": "https://github.com/Staffwerke/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/248178-staffwerke-gmbh/",
-        "name": "Staffwerke GmbH's Repository"
-    },
-    {
-        "url": "https://github.com/tommyvange/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282469-tommyvange/",
-        "name": "tommyvange's Repository"
-    },
-    {
-        "url": "https://github.com/MROGHUB/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/282192-mackattack/",
-        "name": "MackAttack's Repository"
-    },
-    {
-        "url": "https://github.com/7eventy7/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279422-7eventy7/",
-        "name": "7eventy7's Repository"
-    },
-    {
-        "url": "https://github.com/ikoyhn/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/128240-ikoyhn/",
-        "name": "ikoyhn's Repository"
-    },
-    {
-        "url": "https://github.com/hofq/docker-templates",
-        "profile": "https://forums.unraid.net/profile/112121-kippenhof/",
-        "name": "Kippenhof's Repository"
-    },
-    {
-        "url": "https://github.com/bmartino1/unraid-docker-templates",
-        "profile": "https://forums.unraid.net/profile/118010-bmartino1/",
-        "name": "bmartino1's Repository",
-        "communication": "email"
-    },
-    {
-        "url": "https://github.com/jcesclapez/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/280038-darklesc/",
-        "name": "Darklesc's Repository"
-    },
-    {
-        "url": "https://github.com/Aquillacomputingsystem/unraid-templetes",
-        "profile": "https://forums.unraid.net/profile/86880-alphacosmos/",
-        "name": "Alphacosmos' Repository"
-    },
-    {
-        "url": "https://github.com/Groestlcoin/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281950-groestlcoin/",
-        "name": "groestlcoin's Repository"
-    },
-    {
-        "url": "https://github.com/jordan-dalby/unraidtemplates",
-        "profile": "https://forums.unraid.net/profile/281718-data-jordan/",
-        "name": "data-jordan's Repository"
-    },
-    {
-        "url": "https://github.com/giuseppe99barchetta/SuggestArr",
-        "profile": "https://forums.unraid.net/profile/281768-ciuse99/",
-        "name": "ciuse99's Repository",
-        "duplicated": {
-            "ciuse99/suggestarr:latest": true
-        }
-    },
-    {
-        "url": "https://github.com/logandwaters/Plug-and-Play-Docker",
-        "profile": "https://forums.unraid.net/profile/281787-lwater/",
-        "name": "lwater's Repository"
-    },
-    {
-        "url": "https://github.com/apfaffman/docker-templates",
-        "profile": "https://forums.unraid.net/profile/223909-apfaffman/",
-        "name": "apfaffman's Repository"
-    },
-    {
-        "url": "https://github.com/andaks/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/114400-andaks/",
-        "name": "andaks' Repository"
-    },
-    {
-        "url": "https://github.com/GotAnAccount/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/187798-simpleserver/",
-        "name": "simpleServer's Repository"
-    },
-    {
-        "url": "https://github.com/soultaco83/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/87407-soultaco83/",
-        "name": "soultaco83's Repository"
-    },
-    {
-        "url": "https://github.com/D3lta/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281050-decrevi/",
-        "name": "decrevi's Repository"
-    },
-    {
-        "url": "https://github.com/gjhami/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/281298-raidingunraid/",
-        "name": "raidingUnraid's Repository"
-    },
-    {
-        "url": "https://github.com/ne0ark/docker-templates",
-        "profile": "https://forums.unraid.net/profile/221895-naidu/",
-        "name": "Naidu's Repository"
-    },
-    {
-        "url": "https://github.com/feederbox826/unraid-templates",
-        "name": "feederbox826's Repository",
-        "profile": "https://forums.unraid.net/profile/281190-feederbox826/"
-    },
-    {
-        "url": "https://github.com/dkaser/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/244077-edacerton/",
-        "name": "EDACerton's Repository"
-    },
-    {
-        "url": "https://github.com/phyzical/UnraidPlugins",
-        "profile": "https://forums.unraid.net/profile/97031-phyzical/",
-        "name": "phyzical's Repository"
-    },
-    {
-        "url": "https://github.com/zip-fa/unraid-torrserver",
-        "profile": "https://forums.unraid.net/profile/280443-unraidnewbie2211/",
-        "name": "UnraidNewbie2211's Repository",
-        "duplicated": {
-            "ghcr.io/yourok/torrserver": true
-        }
-    },
-    {
-        "url": "https://github.com/Unlearned6688/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/170061-unjustice/",
-        "name": "UnJustice's Repository"
-    },
-    {
-        "url": "https://github.com/DavidWJR/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/253276-reggieswag/",
-        "name": "ReggieSwag's Repository"
-    },
-    {
-        "url": "https://github.com/mmartial/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/15ho4534-martial/",
-        "name": "martial's Repository"
-    },
-    {
-        "url": "https://github.com/rommapp/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279632-arcaneasada/",
-        "name": "arcanesada's Repository"
-    },
-    {
-        "url": "https://github.com/Cobbert/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/129102-cobb/",
-        "name": "cobb's Repository"
-    },
-    {
-        "url": "https://github.com/Cyberschorsch/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279951-cyberschorsch/",
-        "name": "Cyberschorsch's Repository"
-    },
-    {
-        "url": "https://github.com/Schaka/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/243152-schaka/",
-        "name": "Schaka's Repository"
-    },
-    {
-        "url": "https://github.com/lando786/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/270787-thatguyorlando/",
-        "name": "ThatGuyOrlando's Repository",
-        "duplicated": {
-            "triliumnext/notes:latest": true
-        }
-    },
-    {
-        "url": "https://github.com/kclif9/Unraid_Templates",
-        "profile": "https://forums.unraid.net/profile/279194-bluelamp3445/",
-        "name": "blue.lamp3445's Repository"
-    },
-    {
-        "url": "https://github.com/waazaa-fr/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/132702-waazaa/",
-        "name": "waazaa's Repository"
-    },
-    {
-        "url": "https://github.com/bpivk/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/67984-gxs/",
-        "name": "gxs' Repository"
-    },
-    {
-        "url": "https://github.com/l4rm4nd/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/279319-lrvt/",
-        "name": "LVRT's Repository"
-    },
-    {
-        "url": "https://github.com/dgongut/UnRAID-Templates",
-        "profile": "https://forums.unraid.net/profile/250140-dgongut/",
-        "name": "dgongut's Repository"
-    },
-    {
-        "url": "https://github.com/R3yn4ld/unraid-plugins",
-        "profile": "https://forums.unraid.net/profile/77730-reynald/",
-        "name": "Reynald's Repository"
-    },
-    {
-        "url": "https://github.com/donkevlar/Unraid-Docker-Templates",
-        "profile": "https://forums.unraid.net/profile/86041-donkevlar/",
-        "name": "DonKevlar's Repository"
-    },
-    {
-        "url": "https://github.com/mandarons/icloud-drive-docker",
-        "profile": "https://forums.unraid.net/profile/278021-mandarons/",
-        "name": "mandarons' Repository"
-    },
-    {
-        "url": "https://github.com/WaffleMaster22/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/278326-waffle22/",
-        "name": "Waffle22's Repository"
-    },
-    {
-        "url": "https://github.com/Peuuuur-Noel/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/155305-peuuuur-noel/",
-        "name": "Peuuuur Noel's Repository"
-    },
-    {
-        "url": "https://github.com/J000K3R/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/127281-j000k3r/",
-        "name": "J000K3R's Repository"
-    },
-    {
-        "url": "https://github.com/bfox135/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/174793-bfox135/",
-        "name": "Bfox135's Repository"
-    },
-    {
-        "url": "https://github.com/Garethp/rolemaster-era-server-unraid",
-        "profile": "https://forums.unraid.net/profile/243895-garethp/",
-        "name": "Garethp's Repository"
-    },
-    {
-        "url": "https://github.com/czerus/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/277784-sajnti/",
-        "name": "sajnti's Repository"
-    },
-    {
-        "url": "https://github.com/JamsRepos/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
-        "name": "LubricantJam's Repository",
-        "duplicated": {
-            "ghcr.io/schaka/janitorr:native-stable": true
-        }
-    },
-    {
-        "url": "https://github.com/manyfold3d/unraid-templates",
-        "profile": "https://forums.unraid.net/profile/277882-floppyuk/",
-        "name": "FloppyUK's Repository"
-    },
-    {
-        "url": "https://github.com/Entree3k/Unraid-Templates",
-        "profile": "https://forums.unraid.net/profile/201585-entree3000/",
-        "name": "entree3000's Repository"
-  },
-  {
-    "url": "https://github.com/wizarrrr/wizarr",
-    "profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
-    "name": "Official Wizarr Repository"
-  },
-  {
-    "url": "https://github.com/Unknowncall/adsb-unraid-templates",
-    "profile": "https://forums.unraid.net/profile/206238-unknowncall/",
-    "name": "Unknowncall's Repository"
-  },
-  {
-    "url": "https://github.com/J000K3R/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/127281-j000k3r/",
-    "name": "J000K3R's Repository"
-  },
-  {
-    "url": "https://github.com/JW-CH/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/268715-janmer/",
-    "name": "janmer's Repository"
-  },
-  {
-    "url": "https://github.com/petersem/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/240191-petersem/",
-    "name": "petersem's Repository"
-  },
-  {
-    "url": "https://github.com/Collectathon/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/209526-collectathon/",
-    "name": "Collectathon's Repository"
-  },
-  {
-    "url": "https://github.com/RichKidsDev/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/156616-grafgenixs/",
-    "name": "GrafGenixs' Repository"
-  },
-  {
-    "url": "https://github.com/catalinberta/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/258399-dracon/",
-    "name": "dracon's Repository"
-  },
-  {
-    "url": "https://github.com/type0dev/Unraid-Template",
-    "profile": "https://forums.unraid.net/profile/275726-type0dev/",
-    "name": "type0dev's Repository"
-  },
-  {
-    "url": "https://github.com/Richy1989/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/125824-richy1989/",
-    "name": "Richy1989's Repository"
-  },
-  {
-    "url": "https://github.com/iamlite/UnraidCA-GuppyFLO",
-    "profile": "https://forums.unraid.net/profile/275562-lite/",
-    "name": "Lite's Repository"
-  },
-  {
-    "url": "https://github.com/sbondCo/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/274118-unwieldy_dingy/",
-    "name": "unwieldy_dingy's Repository"
-  },
-  {
-    "url": "https://github.com/Drazzilb08/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/63966-drazzilb/",
-    "name": "Drazzilb's Repository"
-  },
-  {
-    "url": "https://github.com/fuzzy01/unraid_plg_repo",
-    "name": "Fuzzy0101's Repository",
-    "profile": "https://forums.unraid.net/profile/143886-fuzzy0101/"
-  },
-  {
-    "name": "pducharme's Repository",
-    "url": "https://github.com/pducharme/docker-containers",
-    "forum": "http://forums.unraid.net/index.php?topic=37058",
-    "profile": "https://forums.unraid.net/profile/62479-pducharme/"
-  },
-  {
-    "name": "Balloob's Repository",
-    "url": "https://github.com/balloob/unraid-docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=36535",
-    "profile": "https://forums.unraid.net/profile/62499-balloob/"
-  },
-  {
-    "name": "Binhex's Repository",
-    "url": "https://github.com/binhex/docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=45811.0",
-    "profile": "https://forums.unraid.net/profile/11148-binhex/"
-  },
-  {
-    "name": "Spants' Repository",
-    "url": "https://github.com/spants/unraidtemplates",
-    "forum": "http://forums.unraid.net/index.php?topic=38486.0",
-    "profile": "https://forums.unraid.net/profile/2148-spants/",
-    "duplicated": {
-        "photostructure/server": true,
-        "pihole/pihole:latest": true
-    }
-  },
-  {
-    "name": "pinion's Repository",
-    "url": "https://github.com/noinip/container-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=38602.0",
-    "profile": "https://forums.unraid.net/profile/10946-pinion/"
-  },
-  {
-    "name": "Bungy's Repository",
-    "url": "https://github.com/jshridha/templates",
-    "forum": "http://forums.unraid.net/index.php?topic=38930.0",
-    "profile": "https://forums.unraid.net/profile/7061-bungy/",
-    "duplicated": {
-      "mysql": true
-    }
-  },
-  {
-    "name": "SlrG's Repository",
-    "url": "https://github.com/SlrG/docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=39050.0",
-    "profile": "https://forums.unraid.net/profile/16166-slrg/"
-  },
-  {
-    "name": "coppit's Repository",
-    "url": "https://github.com/coppit/docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=39561.0",
-    "profile": "https://forums.unraid.net/profile/167-coppit/"
-  },
-  {
-    "name": "hernandito's Repository",
-    "url": "https://github.com/hernandito/docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=39623.0",
-    "profile": "https://forums.unraid.net/profile/6274-hernandito/",
-    "duplicated": {
-      "photoprism/photoprism": true,
-      "romancin/tinymediamanager:latest": true
-    }
-  },
-  {
-    "name": "macester's Repository",
-    "url":  "https://github.com/macexx/docker-templates",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=40630.0",
-    "profile": "https://forums.unraid.net/profile/66302-macester/"
-  },
-  {
-    "name":  "Official Unraid Repository",
-    "url":  "https://github.com/unraid/docker-templates",
-    "shortName": "Unraid",
-    "hideFromCA": {
-        "tailscale/tailscale:stable": true
-    }
-  },
-  {
-    "name":  "linuxserver's Repository",
-    "url":  "https://github.com/linuxserver/templates",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=42092.0"
-  },
-  {
-    "name":  "sdesbure's Repository",
-    "url":  "https://github.com/sdesbure/docker-containers",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=41543.0",
-    "profile": "https://forums.unraid.net/profile/3477-sdesbure/"
-  },
-  {
-    "name": "joch's Repository",
-    "url":  "https://github.com/joch/unraid-docker-templates",
-    "forum":  "http://lime-technology.com/forum/index.php?topic=43480.0",
-    "profile": "https://forums.unraid.net/profile/2607-joch/"
-  },
-  {
-    "name": "tinglis1's Repository",
-    "url":  "https://github.com/tinglis1/docker-containers",
-    "forum": "http://forums.unraid.net/index.php?topic=43970.0",
-    "profile": "https://forums.unraid.net/profile/6492-tinglis1/"
-  },
-  {
-    "name": "Squid's Repository",
-    "url":  "https://github.com/Squidly271/plugin-repository",
-    "profile": "https://forums.unraid.net/profile/10290-squid/",
-    "icon": "https://ipsassets.unraid.net/uploads/monthly_2020_11/1001880086_Tripping-the-Rift-Chode_400x400(1).png.2e62b6b2bd95b73615bc8b651b5615f8.png",
-    "hideFromCA": {
-        "https://raw.githubusercontent.com/Squidly271/docker.categorize/master/plugins/docker.categorize.plg": true,
-        "https://raw.githubusercontent.com/unraid/docker.categorize/master/plugins/docker.categorize.plg": true,
-        "https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg": true,
-        "https://raw.githubusercontent.com/Squidly271/community.applications/master/plugins/community.applications.plg": true,
-        "https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg": true,
-        "https://raw.githubusercontent.com/Squidly271/fix.common.problems/master/plugins/fix.common.problems.plg": true
-    }
-  },
-  {
-    "name": "coppit's Repository",
-    "url":  "https://github.com/coppit/unraid-plugin-metadata",
-    "profile": "https://forums.unraid.net/profile/167-coppit/"
-  },
-  {
-    "name": "dmacias' Repository",
-    "url":  "https://github.com/dmacias72/unRAID-CA",
-    "profile": "https://forums.unraid.net/profile/11874-dmacias/"
-  },
-  {
-    "name": "steini84's Repository",
-    "url": "https://github.com/Steini1984/steini1984-s-repositoy",
-    "profile": "https://forums.unraid.net/profile/2957-steini84/"
-  },
-  {
-    "name": "SlrG's Repository",
-    "url":  "https://github.com/SlrG/unRAID",
-    "profile": "https://forums.unraid.net/profile/16166-slrg/"
-  },
-  {
-    "name": "Emby Repository",
-    "url":  "https://github.com/MediaBrowser/Emby.Build",
-    "forum": "https://lime-technology.com/forum/index.php?topic=45444.0"
-  },
-  {
-    "name": "dibbz' Repository",
-    "url":  "https://github.com/quimnut/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/15731-dibbz/",
-      "duplicated": {
-          "tabbyml/tabby": true
-      }
-  },
-  {
-    "name": "ken-ji's Repository",
-    "url":  "https://github.com/roninkenji/unraid-docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=46401.0",
-    "profile": "https://forums.unraid.net/profile/62359-ken-ji/"
-  },
-  {
-    "name":  "docgyver's Repository",
-    "url":   "https://github.com/docgyver/unraid-v6-plugins",
-    "profile": "https://forums.unraid.net/profile/21303-docgyver/"
-  },
-  {
-    "name":  "bashNinja's Repository",
-    "url":   "https://github.com/miketweaver/docker-templates",
-    "profile": "https://forums.unraid.net/profile/69309-bashninja/"
-  },
-  {
-    "name": "ninthwalker's Repository",
-    "url": "https://github.com/ninthwalker/docker-templates",
-    "profile": "https://forums.unraid.net/profile/9420-ninthwalker/"
-  },
-  {
-    "name":  "Paul_Ber's Repository",
-    "url":  "https://github.com/paulpoco/docker-templates",
-    "profile": "https://forums.unraid.net/profile/69794-paul_ber/",
-    "deprecated": {
-        "wiserain/flexget:latest": true
-    }
-  },
-  {
-    "name": "stuckless' Repository",
-    "url": "https://github.com/stuckless/unRAID",
-    "profile": "https://forums.unraid.net/profile/70058-stuckless/",
-    "duplicated": {
-      "crazifuzzy/opendct": true
-    }    
-  },
-  {
-    "name": "thomast_88's Repository",
-    "url":  "https://github.com/tynor88/docker-templates",
-    "profile": "https://forums.unraid.net/profile/70206-thomast_88/"
-  },
-  {
-    "name": "Bjonness406's Repository",
-    "url": "https://github.com/bjonness406/Docker-templates",
-    "profile": "https://forums.unraid.net/profile/68356-bjonness406/"
-  },
-  {
-    "name": "Huxy's Repository",
-    "url": "https://github.com/HuxyUK/docker-containers",
-    "profile": "https://forums.unraid.net/profile/70544-huxy/"
-  },
-  {
-    "name": "Roland's Repository",
-    "url": "https://github.com/Data-Monkey/docker-templates",
-    "profile": "https://forums.unraid.net/profile/62021-roland/",
-    "duplicated": {
-      "meisnate12/plex-meta-manager": true
-    }
-  },
-  {
-    "name": "jcreynolds' Repository",
-    "url": "https://github.com/jcreynolds/docker-templates",
-    "profile": "https://forums.unraid.net/profile/65204-jcreynoldsii/"
-  },
-  {
-    "name": "JugniJi's Repository",
-    "url": "https://github.com/shaf/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/71085-jugniji/"
-  },
-  {
-    "name": "atribe's Repository",
-    "url": "https://github.com/atribe/unRAID-docker",
-    "forum": "https://lime-technology.com/forum/index.php?topic=51498.0",
-    "profile": "https://forums.unraid.net/profile/70671-atribe/",
-    "duplicated": {
-      "hexparrot/mineos:latest": true,
-        "nicolargo/glances": true
-    }
-  },
-  {
-    "name": "Kru-X's Repository",
-    "url": "https://github.com/Kru-x/unraid-docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=52687.0",
-    "profile": "https://forums.unraid.net/profile/69435-kru-x/",
-    "duplicated": {
-      "mongo": true
-    }
-  },
-  {
-    "name": "jbrodriguez's Repository",
-    "url":  "https://github.com/jbrodriguez/unraid",
-    "profile": "https://forums.unraid.net/profile/593-jbrodriguez/"
-  },
-  {
-    "name": "Waseh's Repository",
-    "url": "https://github.com/Waseh/unraidtemplates",
-    "profile": "https://forums.unraid.net/profile/5193-waseh/"
-  },
-  {
-    "name": "Uirel's Repository",
-    "url": "https://github.com/Poag/docker-xml",
-    "profile": "https://forums.unraid.net/profile/63933-uirel/"
-  },
-  {
-    "name": "Thraxis' Repository",
-    "url": "https://github.com/Thraxis/docker-templates",
-    "profile": "https://forums.unraid.net/profile/9802-thraxis/"
-  },
-  {
-    "name": "cheesemarathon's Repository",
-    "url": "https://github.com/BB-BenBridges/docker-templates",
-    "profile": "https://forums.unraid.net/profile/70291-cheesemarathon/",
-    "duplicated": {
-        "metabase/metabase": true
-    }
-  },
-  {
-    "name": "Taddeusz' Repository",
-    "url": "https://github.com/jason-bean/docker-templates",
-    "profile": "https://forums.unraid.net/profile/71020-taddeusz/",
-    "duplicated": {
-      "mcr.microsoft.com/mssql/server:2019-latest": true
-    }
-  },
-  {
-    "name": "Official Plex Repository",
-    "url": "https://github.com/plexinc/pms-docker",
-    "recommended": true,
-    "shortName": "Plex"
-  },
-  {
-    "name": "clowrym's Repository",
-    "url": "https://github.com/clowrym/docker-templates",
-    "profile": "https://forums.unraid.net/profile/26570-clowrym/"
-  },
-  {
-    "url": "https://github.com/brettm357/docker-templates",
-    "name": "brettm357's Repository",
-    "profile": "https://forums.unraid.net/profile/62222-brettm357/"
-  },
-  {
-    "url": "https://github.com/jlesage/docker-templates",
-    "name": "Djoss' Repository",
-    "profile": "https://forums.unraid.net/profile/73771-djoss/"
-  },
-  {
-    "url": "https://github.com/dlandon/docker.templates",
-    "name": "dlandon's Repository",
-    "profile": "https://forums.unraid.net/profile/6013-dlandon/",
-    "hideFromCA": {
-        "https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices.plg": true,
-        "https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices.plg": true,
-        "https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices.preclear.plg": true,
-        "https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices.preclear.plg": true,
-        "https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices-plus.plg": true,
-        "https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices-plus.plg": true,
-        "https://raw.githubusercontent.com/dlandon/tips.and.tweaks/master/tips.and.tweaks.plg": true,
-        "https://raw.githubusercontent.com/unraid/tips.and.tweaks/master/tips.and.tweaks.plg": true,
-        "https://raw.githubusercontent.com/dlandon/cache_dirs/master/dlandon.cache.dirs.plg": true,
-        "https://raw.githubusercontent.com/unraid/cache_dirs/master/dlandon.cache.dirs.plg": true,
-        "https://raw.githubusercontent.com/dlandon/recycle.bin/master/recycle.bin.plg": true,
-        "https://raw.githubusercontent.com/unraid/recycle.bin/master/recycle.bin.plg": true
-    }
-  },
-  {
-    "url": "https://github.com/JustinAiken/unraid-docker-templates",
-    "name": "JustinAiken's Repository",
-    "profile": "https://forums.unraid.net/profile/1079-justinaiken/"
-  },
-  {
-    "url": "https://github.com/deasmi/unraid-ca",
-    "name": "dsmith44's Repository",
-    "profile": "https://forums.unraid.net/profile/73313-dsmith44/"
-  },
-  {
-    "url": "https://github.com/fanningert/unraid-docker-templates",
-    "name": "fanningert's Repository",
-    "profile": "https://forums.unraid.net/profile/77170-fanningert/",
-    "duplicated": {
-      "coderaiser/cloudcmd:latest-alpine": true
-    }
-  },
-  {
-    "url": "https://github.com/Malfurious/docker-templates",
-    "name": "malfurious' Repository",
-    "profile": "https://forums.unraid.net/profile/77149-malfurious/"
-  },
-  {
-    "url": "https://github.com/malvarez00/unRAID-Docker-Templates",
-    "name": "malvarez00's Repository",
-    "profile": "https://forums.unraid.net/profile/77549-malvarez00/",
-    "duplicated": {
-      "gitlab/gitlab-ce": true
-    }
-  },
-  {
-    "url": "https://github.com/rroller/unraid-templates",
-    "name": "runraid's Repository",
-    "profile": "https://forums.unraid.net/profile/75343-runraid/",
-    "duplicated": {
-      "deepquestai/deepstack": true,
-      "hotio/prowlarr:nightly": true
-    }
-  },
-  {
-    "url": "https://github.com/MarkusMcNugen/docker-templates",
-    "name": "MarkusMcNugen's Repository",
-    "profile": "https://forums.unraid.net/profile/79684-markusmcnugen/",
-    "duplicated": {
-      "technosoft2000/calibre-web": true
-    }
-  },
-  {
-    "url": "https://github.com/juusujanar/unraid-templates",
-    "name": "jj9987's Repository",
-    "profile": "https://forums.unraid.net/profile/79768-jj9987/",
-    "duplicated": {
-      "registry.hub.docker.com/portainer/portainer-ce": true
-    }
-  },
-  {
-    "url": "https://github.com/Jcloud67/Docker-Templates",
-    "name": "JCloud's Repository",
-    "profile": "https://forums.unraid.net/profile/67922-jcloud/",
-    "forum": "https://lime-technology.com/forums/topic/69422-support-qdirstat-and-storj/"
-  },
-  {
-    "url": "https://github.com/tombowditch/docker-templates",
-    "name": "tombowditch's Repository",
-    "profile": "https://forums.unraid.net/profile/80184-tombowditch/"
-  },
-  {
-    "url": "https://github.com/Tautulli/Tautulli-Unraid-Template",
-    "name": "Tautulli's Repository",
-    "profile": "https://forums.unraid.net/profile/69064-wreave/",
-    "recommended": true
-  },
-  {
-    "url": "https://github.com/jbartlett777/DiskSpeed",
-    "name": "JBartlett's Repository",
-    "profile": "https://forums.unraid.net/profile/8307-jbartlett/"
-  },
-  {
-    "url": "https://github.com/zyphermonkey/docker-templates",
-    "name": "zyphermonkey's Repository",
-    "profile": "https://forums.unraid.net/profile/67871-zyphermonkey/"
-  },
-  {
-    "url": "https://github.com/Mudislander/docker-templates",
-    "name": "Mudislander's Repository",
-    "profile": "https://forums.unraid.net/profile/67039-mudislander/"
-  },
-  {
-    "url": "https://github.com/Spikhalskiy/docker-templates",
-    "name": "Spikhalskiy's Repository",
-    "profile": "https://forums.unraid.net/profile/82549-dmitry-spikhalskiy/"
-  },
-  {
-    "url": "https://github.com/digiblur/unraid-docker-templates",
-    "name": "digiblur's Repository",
-    "profile": "https://forums.unraid.net/profile/75995-digiblur/",
-    "forum": "https://lime-technology.com/forums/topic/72033-support-digiblurs-docker-template-repository/",
-    "duplicated": {
-      "deepquestai/deepstack": true,
-      "nico640/docker-unms": true
-    }
-  },
-  {
-    "url": "https://github.com/CorneliousJD/Docker-Templates",
-    "name": "CorneliousJD's Repository",
-    "profile": "https://forums.unraid.net/profile/78194-corneliousjd/",
-    "duplicated": {
-      "ghcr.io/imagegenius/immich:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/mlebjerg/docker-templates",
-    "name": "mlebjerg's Repository",
-    "profile": "https://forums.unraid.net/profile/76816-mlebjerg/"
-  },
-  {
-    "url": "https://github.com/cmccambridge/unraid-templates",
-    "name": "cmccambridge's Repository",
-    "profile": "https://forums.unraid.net/profile/83181-cmccambridge/"
-  },
-  {
-    "url": "https://github.com/itimpi/Unraid-CA-Templates",
-    "name": "itimpi's Repository",
-    "profile": "https://forums.unraid.net/profile/10897-itimpi/"
-  },
-  {
-    "url": "https://github.com/mdarkness1988/rust-server-template",
-    "name": "mdarkness1988's Repository",
-    "profile": "https://forums.unraid.net/profile/84443-mdarkness1988/"
-  },
-  {
-    "url": "https://github.com/DyonR/docker-templates",
-    "name": "Dyon's Repository",
-    "profile": "https://forums.unraid.net/profile/79298-dyon/"
-  },
-  {
-    "url": "https://github.com/dorgan/unraid-templates",
-    "name": "dorgan's Repository",
-    "profile": "https://forums.unraid.net/profile/78375-dorgan/"
-  },
-  {
-    "name": "rix's Repository",
-    "url":  "https://github.com/rix1337/docker-templates",
-    "forum": "http://forums.unraid.net/index.php?topic=43669.0",
-    "profile": "https://forums.unraid.net/profile/67339-rix/"
-  },
-  {
-    "name": "shrmn's Repository",
-    "url": "https://github.com/shrmnk/docker-templates",
-    "profile": "https://forums.unraid.net/profile/77786-shrmn/"
-  },
-  {
-    "url": "https://github.com/SiwatINC/unraid-ca-repository",
-    "name": "Siwat2545's Repository",
-    "profile": "https://forums.unraid.net/profile/72489-siwat2545/",
-    "duplicated": {
-      "zwavejs/zwavejs2mqtt": true,
-      "machinebox/facebox": true
-    }
-  },
-  {
-    "url": "https://github.com/benderstwin/docker-templates",
-    "name": "Bender's Repository",
-    "profile": "https://forums.unraid.net/profile/11326-bryanwirth/",
-    "duplicated": {
-    	"acockburn/appdaemon": true,
-      "traefik:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/dersimn/docker-unraid-templates",
-    "name": "seim's Repository",
-    "profile": "https://forums.unraid.net/profile/11673-seim/",
-    "duplicated": {
-      "seafileltd/seafile": true
-    }
-  },
-  {
-    "url": "https://github.com/fithwum/files-for-dockers",
-    "name": "fithwum's Repository",
-    "profile": "https://forums.unraid.net/profile/82177-fithwum/"
-  },
-  {
-    "url": "https://github.com/olehj/unraid",
-    "name": "FlamongOle's Repository",
-    "profile": "hhttps://forums.unraid.net/profile/86216-flamongole/"
-  },
-  {
-    "url": "https://github.com/GregYankovoy/docker-templates",
-    "profile": "https://forums.unraid.net/profile/88760-grack/",
-    "name": "Grack's Repository"
-  },
-  {
-    "url": "https://github.com/RazorSiM/docker-templates",
-    "name": "raz's Repository",
-    "profile": "https://forums.unraid.net/profile/84655-raz/",
-    "duplicated": {
-      "mprasil/bitwarden": true
-    }
-  },
-  {
-    "url": "https://github.com/maschhoff/docker",
-    "name": "knex666's Repository",
-    "profile": "https://forums.unraid.net/profile/71048-knex666/",
-    "duplicated": {
-      "adolfintel/speedtest": true,
-      "openproject/community:13": true,
-      "filebrowser/filebrowser": true
-    }
-  },
-  {
-    "url": "https://github.com/MobiusNine/docker-templates",
-    "name": "MobiusNine's Repository",
-    "profile": "https://forums.unraid.net/profile/84666-mobiusnine/"
-  },
-  {
-    "url": "https://github.com/Ulisses1478/templates-unraid",
-    "name": "ulisses1478's Repository",
-    "profile": "https://forums.unraid.net/profile/90485-ulisses1478/"
-  },
-  {
-    "url": "https://github.com/FoxxMD/unraid-docker-templates",
-    "name": "FoxxMD's Repository",
-    "profile": "https://forums.unraid.net/profile/85599-foxxmd/"
-  },
-  {
-    "url": "https://github.com/ich777/docker-templates",
-    "name": "ich777's Repository",
-    "profile": "https://forums.unraid.net/profile/72388-ich777/",
-    "duplicated": {
-      "photoprism/photoprism": true
-    },
-    "hideFromCA": {
-        "https://raw.githubusercontent.com/ich777/unraid-nvidia-driver/master/nvidia-driver.plg": true,
-        "https://raw.githubusercontent.com/unraid/unraid-nvidia-driver/master/nvidia-driver.plg": true,
-        "https://raw.githubusercontent.com/ich777/unraid-dvb-driver/master/dvb-driver.plg": true,
-        "https://raw.githubusercontent.com/unraid/unraid-dvb-driver/master/dvb-driver.plg": true,
-        "https://raw.githubusercontent.com/ich777/unraid-coral-driver/master/coral-driver.plg": true,
-        "https://raw.githubusercontent.com/unraid/unraid-coral-driver/master/coral-driver.plg": true
-    }
-  },
-  {
-    "url": "https://github.com/simse/docker-templates",
-    "name": "simse's Repository",
-    "profile": "https://forums.unraid.net/profile/69400-simse/"
-  },
-  {
-    "url": "https://github.com/Josh5/unraid-docker-templates",
-    "name": "Josh.5's Repository",
-    "profile": "https://forums.unraid.net/profile/76627-josh5/"
-  },
-  {
-    "url": "https://github.com/angelics/unraid-docker-template",
-    "name": "josywong's Repository",
-    "profile": "https://forums.unraid.net/profile/7122-josywong/"
-  },
-  {
-    "url": "https://github.com/kubedzero/unraid-community-apps-xml",
-    "name": "kubed_zero's Repository",
-    "profile": "https://forums.unraid.net/profile/12026-kubed_zero/"
-  },
-  {
-    "url": "https://github.com/ijabz/songkong_unraid/",
-    "name": "Official Songkong Repository",
-    "recommended": true,
-    "shortName": "Songkong"
-  },
-  {
-    "url": "https://github.com/tquizzle/Docker-xml",
-    "name": "TQ's Repository",
-    "profile": "https://forums.unraid.net/profile/13228-tq/",
-    "duplicated": {
-        "pufferpanel/pufferpanel": true,
-        "itzg/minecraft-server:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/andrew207/splunk",
-    "name": "Andrew207's Repository",
-    "profile": "https://forums.unraid.net/profile/77842-andrew207/"
-  },
-  {
-    "url": "https://github.com/jbreed/docker-templates",
-    "name": "jbreed's Repository",
-    "profile": "https://forums.unraid.net/profile/92695-jbreed/"
-  },
-  {
-    "url": "https://github.com/selfhosters/unRAID-CA-templates",
-    "name": "Selfhosters Unraid Discord Repository",
-    "shortName": "Selfhosters",
-    "duplicated": {
-      "josh5/unmanic": true,
-      "hotio/plex": true,
-      "hotio/cloudflare-ddns": true,
-      "hotio/hddtemp2influxdb": true,
-      "koenkk/zigbee2mqtt": true,
-      "nwithan8/tauticord:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/alturismo/unraid_templates",
-    "name": "alturismo's Repository",
-    "profile": "https://forums.unraid.net/profile/70845-alturismo/"
-  },
-  {
-    "url": "https://github.com/StevenDTX/unraid-plugin-repository",
-    "name": "StevenD's Repository",
-    "profile": "https://forums.unraid.net/profile/778-stevend/"
-  },
-  {
-    "url": "https://github.com/kiwimato/unraid-templates",
-    "name": "Mihai's Repository",
-    "profile": "https://forums.unraid.net/profile/89549-mihai/"
-  },
-  {
-    "url": "https://github.com/xthursdayx/docker-templates",
-    "profile": "https://forums.unraid.net/profile/69067-zandrsn/",
-    "name": "xthursdayx's Repository",
-    "duplicated": {
-      "benbusby/whoogle-search": true,
-      "nzbgetcom/nzbget:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/d8sychain/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/72950-d8sychain/",
-    "name": "d8sychain's Repository"
-  },
-  {
-    "url": "https://github.com/Dimtar/unraidtemplates",
-    "profile": "https://forums.unraid.net/profile/7694-dimtar/",
-    "name": "dimtar's Repository"
-  },
-  {
-    "url": "https://github.com/SpaceinvaderOne/Docker-Templates-Unraid",
-    "profile": "https://forums.unraid.net/profile/67288-spaceinvaderone/",
-    "name": "SpaceInvaderOne's Repository"
-  },
-  {
-    "url": "https://github.com/d8ahazard/unraid-repository",
-    "name": "d8ahazard's Repository"
-  },
-  {
-    "url": "https://github.com/Knoxie/UnraidTemplates",
-    "name": "Knoxie89's Repository",
-    "profile": "https://forums.unraid.net/profile/78069-knoxie89/"
-  },
-  {
-    "url": "https://github.com/DavidSpek/unraid_docker_templates",
-    "name": "DavidSpek's Repository",
-    "profile": "https://forums.unraid.net/profile/96461-davidspek"
-  },
-  {
-    "url": "https://github.com/AMJidovu/unraid-repository",
-    "name": "Jidovu Marius Adrian's Repository",
-    "profile": "https://forums.unraid.net/profile/86478-jidovu-marius-adrian/"
-  },
-  {
-    "url": "https://github.com/wbynum/docker-templates",
-    "name": "Aggie1999's Repository",
-    "profile": "https://forums.unraid.net/profile/97630-aggie1999/"
-  },
-  {
-    "url": "https://github.com/frakman1/docker-templates",
-    "name": "frakman1's Repository",
-    "profile": "https://forums.unraid.net/profile/96005-frakman1",
-    "duplicated": {
-      "gitlab/gitlab-ce": true,
-      "tynor88/rclone-mount:dev": true,
-      "tynor88/rclone:dev": true,
-      "tynor88/socat": true,
-      "tynor88/unoeuro-dns": true
-    } 
-  },
-  {
-    "url": "https://github.com/ElectricBrainUK/docker-templates",
-    "name": "ElectricBrainUK's Repository",
-    "profile": "https://forums.unraid.net/profile/98185-electricbrainuk"
-  },
-  {
-    "url": "https://github.com/JTok/unraid-plugins",
-    "name": "JTok's Repository",
-    "profile": " https://forums.unraid.net/profile/75269-jtok/"
-  },
-  {
-    "url": "https://github.com/hotio/unraid-templates",
-    "name": "hotio's Repository",
-    "profile": "https://forums.unraid.net/profile/94356-hotio"
-  },
-  {
-    "url": "https://github.com/CyanLabs/unraid-plugins",
-    "name": "Fma965's Repository",
-    "profile": "https://forums.unraid.net/profile/72406-fma965/"
-  },
-  {
-    "url": "https://github.com/Skitals/unraid-ca-templates",
-    "name": "Skitals Repository",
-    "profile": "https://forums.unraid.net/profile/97624-skitals/"
-  },
-  {
-    "url": "https://github.com/ljm42/unraid-templates",
-    "name": "ljm42's Repository",
-    "profile": "https://forums.unraid.net/profile/61877-ljm42/"
-  },
-  {
-    "url": "https://github.com/dcflachs/plugin-repository",
-    "name": "primeval_god's Repository",
-    "profile": "https://forums.unraid.net/profile/63584-primeval_god/"
-  },
-  {
-    "url": "https://github.com/CyaOnDaNet/unraid-templates",
-    "name": "CyaOnDaNet's Repository",
-    "profile": "https://forums.unraid.net/profile/100638-cyaondanet/"
-  },
-  {
-    "url": "https://github.com/A75G/docker-templates",
-    "name": "A75G's Repository",
-    "profile": "https://forums.unraid.net/profile/92683-a75g/",
-    "duplicated": {
-      "vabene1111/recipes:latest": true,
-      "ccarney16/pterodactyl-panel:latest": true,
-      "registry.gitlab.com/timvisee/send:latest": true,
-      "ghcr.io/seriousm4x/upsnap:4": true,
-      "archivebox/archivebox:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/dalekseevs/Unraid-Docker-Templates",
-    "name": "MrChunky's Repository",
-    "profile": "https://forums.unraid.net/profile/74482-mrchunky"
-  },
-  {
-    "url": "https://github.com/RandomNinjaAtk/unraid-templates",
-    "name": "randomninjaatk's Repository",
-    "profile": "https://forums.unraid.net/profile/9890-randomninjaatk/"
-  },
-  {
-    "url": "https://github.com/b3rs3rk/gpustat-unraid",
-    "name": "b3rs3rk's Repository",
-    "profile": "https://forums.unraid.net/profile/103683-b3rs3rk"
-  },
-  {
-    "url": "https://github.com/GuildDarts/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/80260-guilddarts/",
-    "name": "GuildDart's Repository"
-  },
-  {
-    "url": "https://github.com/DavidSpek/homelablabelmaker",
-    "profile": "https://forums.unraid.net/profile/96461-davidspek/",
-    "name": "DavidSpek's Repository"
-  },
-  {
-    "url": "https://github.com/D34DC3N73R/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/101684-d34dc3n73r/",
-    "name": "D34DC3N73R's Repository"
-  },
-  {
-    "url": "https://github.com/kiowadriver/unraid-docker",
-    "profile": "https://forums.unraid.net/profile/74645-kiowa2005/",
-    "name": "kiowa2005's Repository"
-  },
-  {
-    "url": "https://github.com/mikeylikesrocks/unraid-docker-templates",
-    "name": "mikeylikesrocks' Repository",
-    "profile": "https://forums.unraid.net/profile/89382-mikeylikesrocks"
-  },
-  {
-    "url": "https://github.com/P3R-CO/unraid",
-    "name": "capt.asic's Repository",
-    "profile": "https://forums.unraid.net/profile/106374-captasic/"
-  },
-  {
-    "url": "https://github.com/bluegizmo83/DockerXMLs",
-    "name": "bluegizmo83's Repository",
-    "profile": "https://forums.unraid.net/profile/105585-bluegizmo83"
-  },
-  {
-    "url": "https://github.com/Womabre/unraid-docker-templates",
-    "name": "Womabre's Repository",
-    "profile": "https://forums.unraid.net/profile/90075-womabre"
-  },
-  {
-    "url": "https://github.com/SAL-e/docker-templates",
-    "name": "SAL-e's Repository",
-    "profile": "https://forums.unraid.net/profile/11345-sal-e/"
-  },
-  {
-    "url": "https://github.com/GlassedSilver/unRAID-CAs",
-    "name": "Glassed Silver's Repository",
-    "profile": "https://forums.unraid.net/profile/91241-glassed-silver"
-  },
-  {
-    "url": "https://github.com/brianmiller/docker-templates",
-    "name": "TheBrian's Repository",
-    "profile": "https://forums.unraid.net/profile/86892-thebrian"
-  },
-  {
-    "url": "https://github.com/NotExpectedYet/OctoFarm-UnRaid-Template",
-    "name": "mearman's Repository",
-    "profile": "https://forums.unraid.net/profile/100446-mearman"
-  },
-  {
-    "url": "https://github.com/OctoPrint/Unraid-Template",
-     "name": "mearman's 2nd Repository",
-    "profile": "https://forums.unraid.net/profile/100446-mearman",
-    "duplicated": {
-      "octoprint/octoprint:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/ibracorp/unraid-templates",
-    "name": "IBRACORP's Repository",
-    "profile": "https://forums.unraid.net/profile/106623-sycotix/",
-    "duplicated": {
-      "linuxserver/babybuddy": true,
-      "jorenn92/maintainerr:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/natcoso9955/unRAID-docker",
-    "name": "Natcoso9955's Repository",
-    "profile": "https://forums.unraid.net/profile/73128-natcoso9955/"
-  },
-  {
-    "url": "https://github.com/opal06/unraid_docker_templates",
-    "name": "opal_06's Repository",
-    "profile": "https://forums.unraid.net/profile/110756-opal_06/"
-  },
-  {
-    "url": "https://github.com/BGameiro2000/unraid-ca",
-    "profile": "https://forums.unraid.net/profile/110702-bgameiro/",
-    "name": "BGameiro's Repository"
-  },
-  {
-    "url": "https://github.com/openspeedtest/unraid-docker-plugin",
-    "profile": "https://forums.unraid.net/profile/110999-openspeedtest/",
-    "name": "openspeedtest's Repository"
-  },
-  {
-    "url": "https://github.com/charlescng/docker-containers",	
-    "name": "uberchuckie's Repository",	
-    "profile": "https://forums.unraid.net/profile/64811-uberchuckie/"	
-  },
-  {
-    "url": "https://github.com/Organizr/docker-organizr",
-    "name": "Organizr Repository"
-  },
-  {
-    "url": "https://github.com/rantanlan/unraid-templates",
-    "name": "mason's Repository",
-    "profile": "https://forums.unraid.net/profile/914-mason"
-  },
-  {
-    "url": "https://github.com/BoKKeR/RSSTT-Unraid",
-    "name": "BoKKeR's Repository",
-    "profile": "https://forums.unraid.net/profile/94594-bokker"
-  },
-  {
-    "url": "https://github.com/chacawaca/post-recording-xml",
-    "name": "Chacawaca's Repository",
-    "profile": "https://forums.unraid.net/profile/111526-chacawaca"
-  },
-  {
-    "url": "https://github.com/testdasi/testdasi-unraid-repo",
-    "name": "testdasi's Repository",
-    "profile": "https://forums.unraid.net/profile/70144-testdasi"
-  },
-  {
-    "url": "https://github.com/Progeny42/unRAID-CA-Templates",
-    "name": "Progeny42's Repository",
-    "profile": "https://forums.unraid.net/profile/101997-progeny42"
-  },
-  {
-    "url": "https://github.com/roflcoopter/viseron-unraid-ca-template",
-    "name": "roflcoopter's Repository",
-    "profile": "https://forums.unraid.net/profile/113120-roflcoopter"
-  },
-  {
-    "url": "https://github.com/agusalex/docker-templates",
-    "name": "agusalex' Repository",
-    "profile": "https://forums.unraid.net/profile/80800-agusalex"
-  },
-  {
-    "url": "https://github.com/doron1/unraid-plugins",
-    "name": "doron's Repository",
-    "profile": "https://forums.unraid.net/profile/8006-doron/"
-  },
-  {
-    "url": "https://github.com/tmchow/unraid-docker-templates",
-    "name": "tmchow's Repository",
-    "profile": "https://forums.unraid.net/profile/69431-tmchow/"
-  },
-  {
-    "url": "https://github.com/argash/amongusdiscord_unraid",
-    "name": "argash's Repository",
-    "profile": "https://forums.unraid.net/profile/112259-argash/"
-  },
-  {
-    "url": "https://gitlab.com/yayitazale/unraid-templates",
-    "name": "yayitazale's Repository",
-    "profile": "https://forums.unraid.net/profile/88392-yayitazale/"
-  },
-  {
-    "url": "https://github.com/brycelarge/unraid-templates",
-    "name": "brycelarge's Repository",
-    "profile": "https://forums.unraid.net/profile/112270-brycelarge/"
-  },
-  {
-    "url": "https://github.com/jassycliq/Unraid-AndroidStudio-Projector",
-    "name": "jassycliq's Repository",
-    "profile": "https://forums.unraid.net/profile/116233-jassycliq/"
-  },
-  {	
-    "name":  "Linuxserver's Plugin Repository",	
-    "url": "https://github.com/linuxserver/linuxserver-Plugin-Repository"	
-  },
-  {
-    "name": "laur's Repository",
-    "url": "https://github.com/laur89/unraid-templates/",
-    "profile": "https://forums.unraid.net/profile/114193-laur/"
-  },
-  {
-    "url": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
-    "name": "hedrinbc's Repository",
-    "profile": "https://github.com/benhedrington/hedrington-unraid-docker-templates"
-  },
-  {
-    "url": "https://github.com/Sdub76/unraid_docker_templates",
-    "name": "sdub's Repository",
-    "profile": "https://forums.unraid.net/profile/113369-sdub"
-  },
-  {
-    "url": "https://github.com/vinid223/unraid-docker-templates",
-    "name": "vinid223's Repository",
-    "profile": "https://forums.unraid.net/profile/91081-vinid223"
-  },
-  {
-    "url": "https://github.com/DanRegalia/UNRAID",
-    "name": "DanRegalia's Repository",
-    "profile": "https://forums.unraid.net/profile/103107-danregalia/",
-    "duplicated": {
-      "portainer/portainer-ce": true
-    }
-  },
-  {
-    "url": "https://github.com/unraid/language-templates",
-    "name": "Official Unraid Repository",
-    "shortName": "Unraid"
-  },
-  {
-    "url": "https://github.com/diamkil/docker-templates",
-    "name": "diamkil's Repository",
-    "profile": "https://forums.unraid.net/profile/114067-diamkil/"
-  },
-  {
-    "url": "https://github.com/TheAxelander/unraid_ca",
-    "name": "Axelander's Repository",
-    "profile": "https://forums.unraid.net/profile/117678-axelander/"
-  },
-  {
-    "url": "https://github.com/n8detar/docker-templates",
-    "name": "ndetar's Repository",
-    "profile": "https://forums.unraid.net/profile/104222-ndetar/"
-  },
-  {
-    "url": "https://github.com/SimonFair/unraid-plugins",
-    "name": "SimonF's Repository",
-    "profile": "https://forums.unraid.net/profile/75917-simonf"
-  },
-  {
-    "url": "https://github.com/mgutt/unraid-docker-templates",
-    "name": "mgutt's Repository",
-    "profile": "https://forums.unraid.net/profile/94359-mgutt"
-  },
-  {
-    "url": "https://github.com/wger-project/unraid-templates",
-    "name": "rge's Repository",
-    "profile": "https://forums.unraid.net/profile/118956-rge/"
-  },
-  {
-    "url": "https://github.com/ArieDed/unraid-template",
-    "name": "ArieDed's Repository",
-    "profile": "https://forums.unraid.net/profile/119153-arieded/"
-  },
-  {
-    "url": "https://github.com/Muwahhidun/unraid-docker-templates",
-    "name": "Muwahhidun's Repository",
-    "profile": "https://forums.unraid.net/profile/107652-muwahhid/",
-    "duplicated": {
-        "onlyoffice/documentserver-ee": true,
-        "nextcloud/all-in-one:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/nzzane/nzzane-unraid-repo",
-    "profile": "https://forums.unraid.net/profile/113405-flippinturt/",
-    "name": "FlippinTurt's Repository"
-  },
-  {
-    "url": "https://github.com/ganey/unraid-honeygain",
-    "name": "ganey's Repository",
-    "profile": "https://forums.unraid.net/profile/94003-ganey/",
-    "duplicated": {
-      "honeygain/honeygain": true
-    }
-  },
-  {
-    "url": "https://github.com/Flight777/unraid_justworks_templates",
-    "name": "Flight777's Repository",
-    "profile": "https://forums.unraid.net/profile/119250-flight777"
-  },
-  {
-    "url": "https://github.com/PTRFRLL/unraid-templates",
-    "name": "PTRFRLL's Repository",
-    "profile": "https://forums.unraid.net/profile/75102-ptrfrll",
-    "duplicated": {
-      "ghcr.io/meeb/tubesync:v0.9.1": true
-    }
-  },
-  {
-    "url": "https://github.com/Sabreu/unraid_templates",
-    "name": "sublivion's Repository",
-    "profile": "https://forums.unraid.net/profile/98837-sublivion/"
-  },
-  {
-    "url": "https://github.com/zgorizzo69/unraid-templates",
-    "name": "zgo's Repository",
-    "profile": "https://forums.unraid.net/profile/119851-zgo/"
-  },
-  {
-    "url": "https://github.com/bobbintb/docker-templates",
-    "name": "bobbintb's Repository",
-    "profile": "https://forums.unraid.net/profile/550-bobbintb/"
-  },
-  {
-    "url": "https://github.com/C4ArtZ/Unraid-Templates",
-    "name": "c4artz' Repository",
-    "profile": "https://forums.unraid.net/profile/106324-c4artz/"
-  },
-  {
-    "url": "https://github.com/jflo/ffsync-unraid",
-    "name": "Jflo's Repository",
-    "profile": "https://forums.unraid.net/profile/120634-jflo/"
-  },
-  {
-    "url": "https://github.com/Adidasdaniel98/RepetierDocker",
-    "name": "Codeluxe's Repository",
-    "profile": "https://forums.unraid.net/profile/120747-codeluxe/"
-  },
-  {
-    "url": "https://github.com/JmzTaylor/unraid_templates",
-    "name": "jmztaylor's Repository",
-    "profile": "https://forums.unraid.net/profile/120824-jmztaylor/"
-  },
-  {
-    "url": "https://github.com/tenasi/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/121030-johnnyp/",
-    "name": "JohnnyP's Repository"
-  },
-  {
-    "url": "https://github.com/valaypatel/unraidapps",
-    "name": "Yoda's Repository",
-    "profile": "https://forums.unraid.net/profile/120399-yoda/"
-  },
-  {
-    "url": "https://github.com/PotentialIngenuity/petio-unraid",
-    "profile": "https://forums.unraid.net/profile/107700-chargingcosmonaut/",
-    "name": "ChargingCosmonaut's Repository"
-  },
-  {
-    "url": "https://github.com/lnxd/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/114915-lnxd/",
-    "name": "lnxd's Repository"
-  },
-  {
-    "url": "https://github.com/lawryder/unraid_docker_reps",
-    "profile": "https://forums.unraid.net/profile/122425-lawryder/",
-    "name": "LawRyder's Repository"
-  },
-  {
-    "url": "https://github.com/Camc314/unraid-jellyfin-vue",
-    "name": "Camc314's Repository",
-    "profile": "https://forums.unraid.net/profile/123309-camc314/"
-  },
-  {
-    "url": "https://github.com/NixonInnes/unraid-builds-xml",
-    "profile": "https://forums.unraid.net/profile/122748-nixoninnes/",
-    "name": "NixonInnes' Repository"
-  },
-  {
-    "url": "https://github.com/cschanot/docker-templates",
-    "profile": "https://forums.unraid.net/profile/80091-cschanot/",
-    "name": "cschanot's Repository"
-  },
-  {
-    "url": "https://github.com/what-name/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/122982-jacob-bolooni/",
-    "name": "Jacob Bolooni's Repository"
-  },
-  {
-    "url": "https://github.com/EdwardChamberlain/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/122583-forum-layman/",
-    "name": "Forum-Layman's Repository"
-  },
-  {
-    "url": "https://github.com/marzel1/docker-templates",
-    "profile": "https://forums.unraid.net/profile/117249-marzel/",
-    "name": "Marzel's Repository"
-  },
-  {
-    "url": "https://github.com/jsavargas/telethon_downloader",
-    "profile": "https://forums.unraid.net/profile/93593-jsavargas/",
-    "name": "jsavargas' Repository"
-  },
-  {
-    "url": "https://github.com/PartitionPixel/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119008-partition-pixel/",
-    "name": "Partition Pixel's Repository"
-  },
-  {
-    "url": "https://github.com/guydavis/machinaris-unraid",
-    "profile": "https://forums.unraid.net/profile/126090-guydavis/",
-    "name": "guy.davis' Repository"
-  },
-  {
-    "url": "https://github.com/breadlysm/Breads-unraid-templates",
-    "profile": "https://forums.unraid.net/profile/84220-breadlysm/",
-    "name": "breadlysm's Repository"
-  },
-  {
-    "url": "https://github.com/OFark/docker-templates",
-    "profile": "https://forums.unraid.net/profile/86513-ofark/",
-    "name": "OFark's Repository"
-  },
-  {
-    "url": "https://gitlab.com/crafty-controller/crafty-4",
-    "profile": "https://forums.unraid.net/profile/126877-freddy0/",
-    "name": "freddy0's Repository"
-  },
-  {
-    "url": "https://github.com/sgraaf/Unraid-Docker-Templates",
-    "profile": "https://forums.unraid.net/profile/119190-sgraaf/",
-    "name": "sgraaf's Repository",
-    "duplicated": {
-      "adguard/adguardhome": true
-    }
-  },
-  {
-    "url": "https://github.com/aeleos/cloudflared",
-    "profile": "https://forums.unraid.net/profile/78732-aeleos/",
-    "name": "aeleos' Repository"
-  },
-  {
-    "url": "https://github.com/pawelmalak/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119205-paululibro/",
-    "name": "paululibro's Repository"
-  },
-  {
-    "url": "https://github.com/jakemoura/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/118681-jakemoura/",
-    "name": "shaksiwnl's Repository"
-  },
-  {
-    "url": "https://github.com/Marraz/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/127460-marraz/",
-    "name": "Marraz' Repository"
-  },
-  {
-    "url": "https://github.com/daman20/ca-xmls",
-    "profile": "https://forums.unraid.net/profile/122785-daman12/",
-    "name": "daman12's Repository"
-  },
-  {
-    "url": "https://github.com/advplyr/docker-templates",
-    "profile": "https://forums.unraid.net/profile/128533-advplyr/",
-    "name": "advplyr's Repository"
-  },
-  {
-    "url": "https://github.com/vrx-666/unraid-xml",
-    "profile": "https://forums.unraid.net/profile/128590-vrx/",
-    "name": "vrx's Repository"
-  },
-  {
-    "url": "https://github.com/DiamondPrecisionComputing/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/91956-biggiesize/",
-    "name": "Diamond Precision Computing's Repository"
-  },
-  {
-    "url": "https://github.com/ptchernegovski/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/99869-ptchernegovski/",
-    "name": "ptchernegovski's Repository"
-  },
-  {
-    "url": "https://github.com/L1cardo/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/128967-licardo/",
-    "name": "licardo's Repository"
-  },
-  {
-    "url": "https://github.com/kutzilla/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/129184-kutzilla/",
-    "name": "kutzilla's Repository"
-  },
-  {
-    "url": "https://github.com/jkirkcaldy/unraid-CA-templates",
-    "profile": "https://forums.unraid.net/profile/114408-jkirkcaldy/",
-    "name": "jkirkcaldy's Repository"
-  },
-  {
-    "url": "https://github.com/Joshndroid/joshndroid-unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/123042-joshndroid/",
-    "name": "Joshndroid's Repository"
-  },
-  {
-    "url": "https://github.com/Kizaing/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/129591-kizaing/",
-    "name": "Kizaing's Repository"
-  },
-  {
-    "url": "https://github.com/lubeda/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/107977-lubeda/",
-    "name": "LuBeDa's Repository"
-  },
-  {
-    "url": "https://github.com/Frooodle/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/128782-froodle/",
-    "name": "Froodle's Repository",
-    "duplicated": {
-      "selexin/cleanarr": true
-    }
-  },
-  {
-    "url": "https://github.com/rufuswilson/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/130601-cedev/",
-    "name": "cedev's Repository"
-  },
-  {
-    "url": "https://github.com/Joey291/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/99592-cornflake/",
-    "name": "Cornflake's Repository"
-  },
-  {
-    "url": "https://github.com/llalon/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/126527-llalon/",
-    "name": "llalon's Repository"
-  },
-  {
-    "url": "https://github.com/ofawx/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/109310-ofawx/",
-    "name": "ofawx's Repository"
-  },
-  {
-    "url": "https://github.com/photostructure/unraid-template",
-    "profile": "https://forums.unraid.net/profile/116201-mrm/",
-    "name": "Official PhotoStructure Repository",
-    "shortName": "PhotoStructure"
-  },
-  {
-    "url": "https://github.com/BigManDave/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/133103-bigmandave/",
-    "name": "BigManDave's Repository"
-  },
-  {
-    "url": "https://github.com/Olprog59/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/121454-kameleon83/",
-    "name": "Kameleon83's Repository"
-  },
-  {
-    "url": "https://github.com/ItsEcholot/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/134301-echolot/",
-    "name": "Echolot's Repository"
-  },
-  {
-    "url": "https://github.com/redvex2460/docker-templates",
-    "profile": "https://forums.unraid.net/profile/128113-redvex/",
-    "name": "RedVex's Repository"
-  },
-  {
-    "url": "https://github.com/ckocyigit/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/110566-ck98/",
-    "name": "CK98's Repository"
-  },
-  {
-    "url": "https://github.com/pairofcrocs/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/98010-crocs/",
-    "name": "Croc's Repository",
-    "duplicated": {
-      "atdr.meo.ws/archiveteam/warrior-dockerfile:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/Reaparr/Unraid-CA-Templates",
-    "profile": "https://forums.unraid.net/profile/102645-unmax/",
-    "name": "Unmax's Repository",
-    "duplicated": {
-        "plexripper/plexripper:dev": true
-    }
-  },
-  {
-    "url": "https://github.com/IkerSaint/ZFS-Master-Unraid",
-    "profile": "https://forums.unraid.net/profile/102954-iker/",
-    "name": "Iker's Repository"
-  },
-  {
-    "url": "https://github.com/m0ngr31/unraid_ca",
-    "profile": "https://forums.unraid.net/profile/75617-m0ngr31/",
-    "name": "m0ngr31's Repository",
-    "duplicated": {
-      "ghcr.io/ollama-webui/ollama-webui:main": true
-    }
-  },
-  {
-    "url": "https://github.com/corgan2222/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/102466-corgan/",
-    "name": "corgan's Repository"
-  },
-  {
-    "url": "https://github.com/glauth/unraid-glauth",
-    "profile": "https://forums.unraid.net/profile/111590-cyansmoker/",
-    "name": "cyansmoker's Repository"
-  },
-  {
-    "url": "https://github.com/lomorage/unraid-template",
-    "profile": "https://forums.unraid.net/profile/138957-dwebf/",
-    "name": "DwebF's Repository"
-  },
-  {
-    "url": "https://github.com/poke0/Unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/139781-poke0/",
-    "name": "Poke0's Repository"
-  },
-  {
-    "url": "https://github.com/patrickstigler/unraid_app_templates",
-    "profile": "https://forums.unraid.net/profile/139758-maddash1337/",
-    "name": "patrickstigler's Repository",
-    "duplicated": {
-      "mcr.microsoft.com/mssql/server:2019-latest": true,
-        "mandarons/icloud-drive": true
-    }
-  },
-  {
-    "url": "https://github.com/Goobaroo/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/113292-goobaroo/",
-    "name": "Goobaroo's Repository"
-  },
-  {
-    "url": "https://github.com/TrophyBuck/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/140258-trophybuck/",
-    "name": "TrophyBuck's Repository"
-  },
-  {
-    "url": "https://github.com/knilix/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/126551-da-do-ron/",
-    "name": "da do ron's Repository"
-  },
-  {
-    "url": "https://github.com/C3004/Unraid-Templates-C3004",
-    "profile": "https://forums.unraid.net/profile/142775-c3004/",
-    "name": "C3004's Repository"
-  },
-  {
-    "url": "https://github.com/jorgenman/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/142946-jorgenman/",
-    "name": "jorgenman's Repository"
-  },
-  {
-    "url": "https://github.com/lordfiSh/unraid-docker-images",
-    "profile": "https://forums.unraid.net/profile/92815-lordfish/",
-    "name": "lordfiSh's Repository"
-  },
-  {
-    "url": "https://github.com/fileflows/FileFlowsUnraid",
-    "profile": "https://forums.unraid.net/profile/1117-reven/",
-    "name": "fileflows's Repository"
-  },
-  {
-    "url": "https://github.com/L4stIdi0t/Unraid-template",
-    "profile": "https://forums.unraid.net/profile/122421-l4stidi0t/",
-    "name": "L4stIdi0t's Repository"
-  },
-  {
-    "url": "https://github.com/StuffAnThings/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/76370-bobokun/",
-    "name": "bobokun's Repository"
-  },
-  {
-    "url": "https://github.com/locus313/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/74415-locus313/",
-    "name": "locus313's Repository"
-  },
-  {
-    "url": "https://github.com/ivaxor/unraid-ca-docker-templates",
-    "profile": "https://forums.unraid.net/profile/147445-saskiuhia/",
-    "name": "saskiuhia's Repository"
-  },
-  {
-    "url": "https://github.com/bonedrums/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/72855-bonedrums/",
-    "name": "bonedrums' Repository"
-  },
-  {
-    "url": "https://github.com/josecoelho/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/125944-jos%C3%A9-coelho/",
-    "name": "José Coelho's Repository"
-  },
-  {
-    "url": "https://github.com/Sander0542/docker-templates",
-    "profile": "https://forums.unraid.net/profile/98342-sander0542/",
-    "name": "Sander0542's Repository"
-  },
-  {
-    "url": "https://github.com/mizz141/mizz141-unraid-xml",
-    "profile": "https://forums.unraid.net/profile/98815-mizz141/",
-    "name": "Mizz141's Repository"
-  },
-  {
-    "url": "https://github.com/OpenSageTV/unRAID",
-    "profile": "https://forums.unraid.net/profile/125876-jusjoken/",
-    "name": "jusjoken's Repository"
-  },
-  {
-    "url": "https://github.com/MasterEvarior/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/140790-smithynithy/",
-    "name": "SmithyNithy's Repository"
-  },
-  {
-    "url": "https://github.com/qubex22/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/110563-joroga22/",
-    "name": "joroga22's Repository"
-  },
-  {
-    "url": "https://github.com/timstephens24/docker-templates",
-    "profile": "https://forums.unraid.net/profile/67918-timstephens24/",
-    "name": "timstephens24's Repository"
-  },
-  {
-    "url": "https://github.com/simonsickle/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/152551-ssickle/",
-    "name": "ssickle's Repository",
-    "duplicated": {
-      "influxdb": true,
-      "ghcr.io/home-assistant/home-assistant": true
-    }
-  },
-  { 
-    "url": "https://github.com/oldcrazyeye/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/124305-oldcrazyeye/",
-    "name": "oldcrazyeye's Repository"
-  },
-  {
-    "url": "https://github.com/UnknownHiker/unraid-template-kitchenowl",
-    "profile": "https://forums.unraid.net/profile/155012-hansolo97/",
-    "name": "HanSolo97's Repository"
-  },
-  {
-    "url": "https://github.com/ciegg/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/155366-cieg/",
-    "name": "cieg's Repository"
-  },
-  {
-    "url": "https://github.com/FrankM77/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/153626-built2succeed/",
-    "name": "Built2Succeed's Repository"
-  },
-  {
-    "url": "https://github.com/xenco/docker-templates",
-    "profile": "https://forums.unraid.net/profile/155847-xenco/",
-    "name": "xenco's Repository"
-  },
-  {
-    "url": "https://github.com/helfrichmichael/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/68815-mikeah/",
-    "name": "MikeAH's Repository"
-  },
-  {
-    "url": "https://github.com/pierot/unraid-ca-apps",
-    "profile": "https://forums.unraid.net/profile/121203-pieterm/",
-    "name": "pieterm's Repository"
-  },
-  {
-    "url": "https://github.com/crazyqin/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/157513-mrafter/",
-    "name": "mrafter's Repository"
-  },
-  {
-    "url": "https://github.com/imTHAI/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/117577-pbear/",
-    "name": "pbear's Repository"
-  },
-  {
-    "url": "https://github.com/tipdec-siblyn/Urbit-on-Unraid",
-    "profile": "https://forums.unraid.net/profile/158043-tipdec-siblyn/",
-    "name": "tipdec-sbilyn's Repository"
-  },
-  {
-    "url": "https://github.com/MyFaith/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/157465-myfaith/",
-    "name": "MyFaith's Repository"
-  },
-  {
-    "url": "https://github.com/ep1cman/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/69221-ep1cman/",
-    "name": "ep1cman's Repository"
-  },
-  {
-    "url": "https://github.com/picthor-io/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/106558-realcnbs/",
-    "name": "realcnbs' Repository"
-  },
-  {
-    "url": "https://github.com/ItJustFox/unraidtemplate",
-    "profile": "https://forums.unraid.net/profile/142238-fantucie/",
-    "name": "Fantucie's Repository"
-  },
-  {
-    "url": "https://github.com/juchong/shapeshifter-docker-unraid",
-    "profile": "https://forums.unraid.net/profile/113997-juchong/",
-    "name": "juchong's Repository"
-  },
-  {
-    "url": "https://github.com/avpnusr/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/126700-fatzcat/",
-    "name": "FatzCat's Repository"
-  },
-  {
-    "url": "https://github.com/xavier-hernandez/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/158924-xavierh/",
-    "name": "xavierh's Repository",
-    "duplicated": {
-      "jlongster/actual-server:latest": true,
-        "xavierh/goaccess-for-nginxproxymanager": true
-    }
-  },
-  {
-    "url": "https://github.com/imthenachoman/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/134093-imthenachoman/",
-    "name": "IMTheNachoMan's Repository"
-  },
-  {
-    "url": "https://github.com/silman/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/163023-silman/",
-    "name": "silman's Repository"
-  },
-  {
-    "url": "https://github.com/JulienPlomteux/Unraid-ErgoNode",
-    "profile": "https://forums.unraid.net/profile/163009-mrlafontaine/",
-    "name": "mrlafontaine's Repository"
-  },
-  {
-    "url": "https://github.com/SavageAUS/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/91260-savageaus/",
-    "name": "SaveageAUS' Repository",
-    "duplicated": {
-      "ajnart/homarr": true
-    }
-  },
-  {
-    "url": "https://github.com/GladysAssistant/unraid-gladys-templates",
-    "profile": "https://forums.unraid.net/profile/159169-jgcb00/",
-    "name": "jgcb00's Repository"
-  },
-  {
-    "url": "https://github.com/xWeegix/templates",
-    "profile": "https://forums.unraid.net/profile/132338-xweegix/",
-    "name": "xWeegix's Repository",
-    "duplicated": {
-      "fallenbagel/jellyseerr:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/tubearchivist/unraid-templates",
-    "name": "TubeArchivist's Official Repository"
-  },
-  {
-    "url": "https://github.com/djismgaming/docker-templates",
-    "profile": "https://forums.unraid.net/profile/124577-djismgaming/",
-    "name": "djismgaming's Repository"
-  },
-  {
-    "url": "https://github.com/Darkside138/unraidtemplates",
-    "profile": "https://forums.unraid.net/profile/166210-darkside138/",
-    "name": "Darkside138's Repository"
-  },
-  {
-    "url": "https://github.com/soerentsch/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/146285-gucky79/",
-    "name": "gucky79's Repository"
-  },
-  {
-    "url": "https://github.com/maxcerny/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/93919-sysco/",
-    "name": "sysco's Repository"
-  },
-  {
-    "url": "https://github.com/JPDVM2014/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/156525-jpdvm2014/",
-    "name": "JPDVM2014's Repository",
-    "duplicated": {
-      "tomsquest/docker-radicale": true
-    }
-  },
-  {
-    "url": "https://github.com/Qlisch/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119212-kulisch/",
-    "name": "Kulisch's Repository"
-  },
-  {
-    "url": "https://github.com/sems/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/168805-sem/",
-    "name": "sem's Repository"
-  },
-  {
-    "url": "https://github.com/Th0masDB/unraid_template",
-    "profile": "https://forums.unraid.net/profile/126905-thomasdb__/",
-    "name": "ThomasDB's Repository"
-  },
-  {
-    "url": "https://github.com/NickM-27/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/128178-crzynik/",
-    "name": "crzynik's Repository"
-  },
-  {
-    "url": "https://github.com/simonjenny/unraid",
-    "profile": "https://forums.unraid.net/profile/122229-simon-jenny/",
-    "name": "Simon Jenny's Repository"
-  },
-  {
-    "url": "https://github.com/superboki/UNRAID-FR",
-    "profile": "https://forums.unraid.net/profile/92630-superboki/",
-    "name": "superboki's Repository",
-    "duplicated": {
-      "ghcr.io/taxel/plextraktsync:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/jadehawk/unRaid-Templates",
-    "profile": "https://forums.unraid.net/profile/168612-jadehawk",
-    "name": "Jadehawk's Repository"
-  },
-  {
-    "url": "https://github.com/LeonStoldt/Unraid-Community-Applications",
-    "profile": "https://forums.unraid.net/profile/170522-leonstoldt/",
-    "name": "LeonStoldt's Repository"
-  },
-  {
-    "url": "https://github.com/moritzfl/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/145080-moritzf/",
-    "name": "moritzf's Repository"
-  },
-  {
-    "url": "https://github.com/ShaneIsrael/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/168827-shane-israel/",
-    "name": "Shane Israel's Repository"
-  },
-  {
-    "url": "https://github.com/vertex-app/docker-template",
-    "profile": "https://forums.unraid.net/profile/171336-%E6%A0%97%E5%B1%B1%E6%9C%AA%E6%9D%A5/",
-    "name": "栗山未来 Repository"
-  },
-  {
-    "url": "https://github.com/mingzaily/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/169573-longyunur/",
-    "name": "LongYunar's Repository"
-  },
-  {
-    "url": "https://github.com/geoffgbsn/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/144116-geoffgibby/",
-    "name": "geoff.gibby's Repository"
-  },
-  {
-    "url": "https://github.com/tritones/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/172136-tritones/",
-    "name": "tritones' Repository"
-  },
-  {
-    "url": "https://github.com/Vilhjalmr26/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/126802-vilhjalmr/",
-    "name": "Vilhjalmr's Repository"
-  },
-  {
-    "url": "https://github.com/Ratomas/CA_XML",
-    "profile": "https://forums.unraid.net/profile/85867-robert-thomas/",
-    "name": "Robert Thomas' Repository"
-  },
-  {
-    "url": "https://github.com/fiR3W4LL87/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/113873-fir3w4ll/",
-    "name": "fiR3W4LL's Repository",
-    "Deprecated": true
-  },
-  {
-    "url": "https://github.com/CollinHeist/UnraidConfig",
-    "profile": "https://forums.unraid.net/profile/172758-collinheist/",
-    "name": "CollinHeist's Repository"
-  },
-  {
-    "url": "https://github.com/Loony2392/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/152355-loony2392/",
-    "name": "Loony2392's Repository"
-  },
-  {
-    "url": "https://github.com/mikedhanson/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/88846-mikehanson/",
-    "name": "mikehanson's Repository"
-  },
-  {
-    "url": "https://github.com/kywarai/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/170658-kuuki/",
-    "name": "kuuki's Repository"
-  },
-  {
-    "url": "https://github.com/KasteM34/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/169707-kastem34/",
-    "name": "kastem34's Repository",
-    "duplicated": {
-      "hashicorp/vault": true
-    }
-  },
-  {
-    "url": "https://github.com/luisalrp/unraid_docker_templates",
-    "profile": "https://forums.unraid.net/profile/115058-luisalrp/",
-    "name": "luisalrp's Repository"
-  },
-  {
-    "url": "https://github.com/Yoruio/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/126098-yoruio/",
-    "name": "Yoruio's Repository"
-  },
-  {
-    "url": "https://github.com/Polemus/Unraid",
-    "profile": "https://forums.unraid.net/profile/140455-dusty-roberts/",
-    "name": "Dusty Roberts' Repository"
-  },
-  {
-    "url": "https://github.com/kilrah/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/175398-kilrah/",
-    "name": "Kilrah's Repository"
-  },
-  {
-    "url": "https://github.com/ahmadnassri/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/123283-ahmad/",
-    "name": "Ahmad's Repository"
-  },
-  {
-    "url": "https://github.com/ibigsnet/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/76488-riflejock/",
-    "name": "RifleJock's Repository"
-  },
-  {
-    "url": "https://github.com/MountainGod2/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/167420-mrslaw/",
-    "name": "mrslaw's Repository",
-    "duplicated": {
-        "corentinth/it-tools": true
-    }
-  },
-  {
-    "url": "https://github.com/Aerilym/docker-templates",
-    "profile": "https://forums.unraid.net/profile/158147-aerilym/",
-    "name": "Aerilym's Repository"
-  },
-  {
-    "url": "https://github.com/its-sven/docker-templates",
-    "profile": "https://forums.unraid.net/profile/146810-sven-w%C3%BCrth/",
-    "name": "Sven Würth's Repository"
-  },
-  {
-    "url": "https://github.com/Srcodesalittle/cryptgeon_redis",
-    "profile": "https://forums.unraid.net/profile/131563-lamp/",
-    "name": "lamp's Repository"
-  },
-  {
-    "url": "https://github.com/thecode/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/109528-thecode/",
-    "name": "thecode's Repository"
-  },
-  {
-    "url": "https://github.com/0neTX/UnRAID_Template",
-    "profile": "https://forums.unraid.net/profile/161660-onetx/",
-    "name": "onetx's Repository"
-  },
-  {
-    "url": "https://github.com/dhruvinsh/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/146712-dhruvin/",
-    "name": "Dhruvin's Repository"
-  },
-  {
-    "url": "https://github.com/alexbn71/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/169325-alexbn71/",
-    "name": "alexbn71's Repository"
-  },
-  {
-    "url": "https://github.com/kennethprose/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/174044-roseatoni/",
-    "name": "roseatoni's Repository"
-  },
-  {
-    "url": "https://github.com/twist3dimages/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/137900-exes/",
-    "name": "Exes' Repository",
-    "duplicated": {
-      "clamav/clamav": true
-    }
-  },
-  {
-    "url": "https://github.com/chrizzo84/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/135280-chrizzo/",
-    "name": "chrizzo's Repository",
-    "duplicated": {
-        "drone/drone": true,
-        "docker.io/jc21/nginx-proxy-manager": true    
-    }
-  },
-  {
-    "url": "https://github.com/devzwf/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/119200-zappyzap/",
-    "name": "ZappyZap's Repository",
-    "duplicated": {
-        "lscr.io/linuxserver/speedtest-tracker:latest": true,
-        "l4rm4nd/vouchervault:1.1.x": true,
-        "l4rm4nd/vouchervault:1.4.x": true,
-        "l4rm4nd/vouchervault:1.5.x": true
-    }
-  },
-  {
-    "url": "https://github.com/ChongZhiJie0216/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/114492-chongzhijie/",
-    "name": "ChongZhiJie's Repository"
-  },
-  {
-    "url": "https://github.com/elzik/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/201488-elzik/",
-    "name": "elzik's Repository"
-  },
-  {
-    "url": "https://github.com/Mavrag/unraid-templates",
-    "name": "Mavrag's Repository",
-    "profile": "https://forums.unraid.net/profile/111982-mavrag/"
-  },
-  {
-    "url": "https://github.com/AriaGomes/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/107309-figro/",
-    "name": "Figro's Repository"
-  },
-  {
-    "url": "https://github.com/daredoes/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/157186-daredoes/",
-    "name": "daredoes' Repository"
-  },
-  {
-    "url": "https://github.com/masterwishx/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/107418-masterwishx/",
-    "name": "Masterwishx's Repository"
-  },
-  {
-    "url": "https://github.com/lewislarsen/lldap-unraid",
-    "profile": "https://forums.unraid.net/profile/143760-lewis-l/",
-    "name": "Lewis L's Repository"
-  },
-  {
-    "url": "https://github.com/piranha771/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/159409-divid/",
-    "name": "Divid's Repository",
-    "duplicated": {
-      "seafileltd/seafile-mc": true
-    }
-  },
-  {
-    "url": "https://github.com/jwillmer/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119261-jwillmer/",
-    "name": "jwillmer's Repository"
-  },
-  {
-    "url": "https://github.com/Zggis/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/118712-zggis/",
-    "name": "Zggis' Repository"
-  },
-  {
-    "url": "https://github.com/josh-gaby/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/171871-joshgaby/",
-    "name": "josh.gaby's Repository"
-  },
-  {
-    "url": "https://github.com/emptyfish/unraid-apps",
-    "profile": "https://forums.unraid.net/profile/112283-emptyfish/",
-    "name": "emptyfish's Repository"
-  },
-  {
-    "url": "https://github.com/pyrater/docker-templates",
-    "profile": "https://forums.unraid.net/profile/14118-pyrater/",
-    "name": "pyrater's Repository"
-  },
-  {
-    "url": "https://github.com/Kostecki/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/68040-kostecki/",
-    "name": "kostecki's Repository"
-  },
-  {
-    "url": "https://github.com/Balya/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/166805-balya/",
-    "name": "Balya's Repository"
-  },
-  {
-    "url": "https://github.com/ccmpbll/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/5869-ccmpbll/",
-    "name": "ccmpbll's Repository"
-  },
-  {
-    "url": "https://github.com/7oasty/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/189568-7oasty/",
-    "name": "7oasty's Repository"
-  },
-  {
-    "url": "https://github.com/Commifreak/unraid-plugins",
-    "profile": "https://forums.unraid.net/profile/140912-kluthr/",
-    "name": "KluthR's Repository"
-  },
-  {
-    "url": "https://github.com/m-klecka/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/210341-mklecka/",
-    "name": "mklecka's Repository"
-  },
-  {
-    "url": "https://github.com/PonyLucky/TendaControllerXML",
-    "profile": "https://forums.unraid.net/profile/177818-margot/",
-    "name": "Margot's Repository"
-  },
-  {
-    "url": "https://github.com/Kometa-Team/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/198915-sohjiro/",
-    "name": "Sohjiro's Repository"
-  },
-  {
-    "url": "https://github.com/dannymate/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/87501-jimrummy101/",
-    "name": "jimrummy101's Repository"
-  },
-  {
-    "url": "https://github.com/AlexGreenUK/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/116574-alexgreenuk/",
-    "name": "AlexGreenUK's Repository"
-  },
-  {
-    "url": "https://github.com/theimmortal68/zappiti-server-docker",
-    "profile": "https://forums.unraid.net/profile/67130-theimmortal/",
-    "name": "theimmortal's Repository"
-  },
-  {
-    "url": "https://github.com/manuel-rw/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/138040-manrw/",
-    "name": "manrw's Repository"
-  },
-  {
-    "url": "https://github.com/nwithan8/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/81372-grtgbln/",
-    "name": "grtgbln's Repository",
-    "duplicated": {
-        "binwiederhier/ntfy:latest": true,
-        "networkstatic/iperf3:latest": true,
-        "ghcr.io/eliasbenb/plexanibridge:latest": true,
-        "ghcr.io/maybe-finance/maybe:stable": true,
-        "ghcr.io/mediux-team/aura:latest": true,
-        "cirx08/wedding_share:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/sebtech33/unRAID-Templates",
-    "profile": "https://forums.unraid.net/profile/98806-sebtech33/",
-    "name": "SebTech33's Repository",
-    "duplicated": {
-      "crazymax/rtorrent-rutorrent": true
-    }
-  },
-  {
-    "url": "https://github.com/Belstrekkie/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/224258-bversluis/",
-    "name": "BVersluis' Repository"
-  },
-  {
-    "url": "https://github.com/imagegenius/templates",
-    "profile": "https://forums.unraid.net/profile/103573-vcxpz/",
-    "name": "imagegenius' Repository"
-  },
-  {
-    "url": "https://github.com/FreakErn/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/129382-freakern/",
-    "name": "FreakErn's Repository"
-  },
-  {
-    "url": "https://github.com/wupasscat/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/103746-wupasscat/",
-    "name": "wupasscat's Repository"
-  },
-  {
-    "url": "https://github.com/mplogas/unraid-containers",
-    "profile": "https://forums.unraid.net/profile/145679-mplogas/",
-    "name": "mplogas' Repository"
-  },
-  {
-    "url": "https://github.com/warieon/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/240351-warieon/",
-    "name": "warieon's Repository"
-  },
-  {
-    "url": "https://github.com/PepaonDrugs/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/157546-maxi_fpv/",
-    "name": "Maxi_Fpv's Repository"
-  },
-  {
-    "url": "https://github.com/Nackophilz/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/161066-nackophilz/",
-    "name": "Nackophilz's Repository"
-  },
-  {
-    "url": "https://github.com/brockbreacher/join-bot-unraid",
-    "profile": "https://forums.unraid.net/profile/171183-brockbreacher/",
-    "name": "brockbreacher's Repository"
-  },
-  {
-    "url": "https://github.com/killforby/chibisafe",
-    "profile": "https://forums.unraid.net/profile/229087-professeurx/",
-    "name": "professeurx's Repository"
-  },
-  {
-    "url": "https://github.com/npmSteven/Unraid-VM-CP",
-    "profile": "https://forums.unraid.net/profile/102900-stevenrafferty/",
-    "name": "StevenRafferty's Repository"
-  },
-  {
-    "url": "https://github.com/mastiffmushroom/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/243288-mastiffmushroom/",
-    "name": "MastiffMushroom's Repository"
-  },
-  {
-    "url": "https://github.com/mattheworres/docker-templates",
-    "profile": "https://forums.unraid.net/profile/115370-matthew-orres/",
-    "name": "Matthew Orres' Repository"
-  },
-  {
-    "url": "https://github.com/DatPat/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/169502-jsrk/",
-    "name": "jsrk's Repository"
-  },
-  {
-    "url": "https://github.com/terratrax/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/230036-terratrax/",
-    "name": "terratrax's Repository"
-  },
-  {
-    "url": "https://github.com/THESHULK/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/237924-the_shulk/",
-    "name": "THE_SHULK's Repository"
-  },
-  {
-    "url": "https://github.com/kezzkezzkezz/UNRAID-Templates/",
-    "profile": "https://forums.unraid.net/profile/133849-kezzkezzkezz/",
-    "name": "kezzkezzkezz's Repository"
-  },
-  {
-    "url": "https://github.com/luigi311/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/72460-luigi311/",
-    "name": "Luigi311's Repository"
-  },
-  {
-    "url": "https://github.com/friendlyFriend4000/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/244776-friendlyfriend/",
-    "name": "FriendlyFriend's Repository"
-  },
-  {
-    "url": "https://github.com/fizzyfrys/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119591-fizzyfrys/",
-    "name": "fizzyfrys' Repository"
-  },
-  {
-    "url": "https://github.com/giganode/unraid-plugins",
-    "profile": "https://forums.unraid.net/profile/105464-giganode/",
-    "name": "giganode's Repository"
-  },
-  {
-    "url": "https://github.com/zhtengw/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/245393-zhtengw/",
-    "name": "zhtengw's Repository"
-  },
-  {
-    "url": "https://github.com/laromicas/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/172751-laromicas/",
-    "name": "laromicas' Repository"
-  },
-  {
-    "url": "https://github.com/seriousm4x/unraid-community-apps",
-    "profile": "https://forums.unraid.net/profile/246841-seriousm4x/",
-    "name": "seriousm4x's Repository"
-  },
-  {
-    "url": "https://github.com/b42n1/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/167912-b4rny/",
-    "name": "B4rny's Repository",
-    "duplicated": {
-      "frooodle/s-pdf": true
-    }
-  },
-  {
-    "url": "https://github.com/untraceablez/uvdesk-unraid",
-    "profile": "https://forums.unraid.net/profile/111430-untraceablez/",
-    "name": "untraceablez' Repository"
-  },
-  {
-    "url": "https://github.com/JACOBSMILE/Unraid_XMLS",
-    "profile": "https://forums.unraid.net/profile/141756-jacobsmile/",
-    "name": "JACOBSMILE's Repository"
-  },
-  {
-    "url": "https://github.com/JakeShirley/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/101291-darknavi/",
-    "name": "darknavi's Repository"
-  },
-  {
-    "url": "https://github.com/taha-yassine/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/248389-vodros/",
-    "name": "Vodros' Repository"
-  },
-  {
-    "url": "https://github.com/riffsphereha/Unraid-Templates",
-    "profile": "https://forums.unraid.net/profile/250924-riffsphereha/",
-    "name": "RiffSphereHA's Repository"
-  },
-  {
-    "url": "https://github.com/coreylane/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/146143-coreylane/",
-    "name": "coreylane's Repository"
-  },
-  {
-    "url": "https://github.com/snapcrescent/templates",
-    "profile": "https://forums.unraid.net/profile/226383-navalgandhi1989/",
-    "name": "snapcrescent's Repository"
-  },
-  {
-    "url": "https://github.com/mpcdigitize/docker-templates",
-    "profile": "https://forums.unraid.net/profile/249625-petel/",
-    "name": "PeteL's Repository"
-  },
-  {
-    "url": "https://github.com/McJoppy/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/250622-mcraidy/",
-    "name": "mcraidy's Repository"
-  },
-  {
-    "url": "https://github.com/findthelorax/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/169140-findthelorax/",
-    "name": "Findthelorax's Repository"
-  },
-  {
-    "url": "https://github.com/j1philli/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/84279-j1philli/",
-    "name": "j1philli's Repository"
-  },
-  {
-    "url": "https://github.com/lucamarchiori/OwnTracksRecorderUnraid",
-    "profile": "https://forums.unraid.net/profile/255135-lucamarchiori/",
-    "name": "lucamarchiori's Repository"
-  },
-  {
-    "url": "https://github.com/jinlife/docker-templates",
-    "profile": "https://forums.unraid.net/profile/119719-jinlife/",
-    "name": "jinlife's Repository"
-  },
-  {
-    "url": "https://github.com/RealFascinated/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/87787-imfascinated/",
-    "name": "ImFascinated's Repository"
-  },
-  {
-    "url": "https://github.com/criscrafter/Unraid-CA",
-    "profile": "https://forums.unraid.net/profile/154961-criscrafter/",
-    "name": "criscrafter's Repository"
-  },
-  {
-    "url": "https://github.com/criblio/unraid",
-    "profile": "https://forums.unraid.net/profile/256028-criblio/",
-    "name": "Criblio's Repository"
-  },
-  {
-    "url": "https://github.com/W3LFARe/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/129748-welfare/",
-    "name": "welfare's Repository"
-  },
-  {
-    "url": "https://github.com/greycubesgav/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/119829-beastieg/",
-    "name": "beastieg's Repository"
-  },
-  {
-    "url": "https://github.com/vLX42/backdrop-generator",
-    "profile": "https://forums.unraid.net/profile/288463-vlx42/",
-    "name": "vlx42's Repository"
-  },
-  {
-    "url": "https://github.com/scolcipitato/plugin-repository",
-    "profile": "https://forums.unraid.net/profile/109953-scolcipitato/",
-    "name": "scolcipitato's Repository"
-  },
-  {
-    "url": "https://github.com/hoody424/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/127129-hoody424/",
-    "name": "hoody424's Repository"
-  },
-  {
-    "url": "https://github.com/skrashevich/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/198957-svk/",
-    "name": "svk's Repository"
-  },
-  {
-    "url": "https://github.com/Muxelmann/unraid-app_anaconda3",
-    "profile": "https://forums.unraid.net/profile/238596-muxelmann/",
-    "name": "muxelmann's Repository"
-  },
-  {
-    "url": "https://github.com/hudikhq/hoodik-unraid",
-    "profile": "https://forums.unraid.net/profile/228687-htunlogic/",
-    "name": "htunlogic's Repository"
-  },
-  {
-    "url": "https://github.com/edgar971/open-chat",
-    "profile": "https://forums.unraid.net/profile/238357-el_pino/",
-    "name": "el_pino's Repository"
-  },
-  {
-    "url": "https://github.com/evilalmus/UNRAID_COMMUNITY_APPS",
-    "profile": "https://forums.unraid.net/profile/178171-almus/",
-    "name": "almus' Repository"
-  },
-  {
-    "url": "https://github.com/ArabCoders/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/260951-ac-watchstate/",
-    "name": "AC-WatchState's Repository"
-  },
-  {
-    "url": "https://github.com/ImSkully/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/186901-imskully/",
-    "name": "ImSkully's Repository"
-  },
-  {
-    "url": "https://github.com/BitlessByte0/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/261347-bitlessbyte/",
-    "name": "BitlessByte's Repository"
-  },
-  {
-    "url": "https://github.com/SamTV12345/podfetch-unraid-config",
-    "profile": "https://forums.unraid.net/profile/261451-samtv12345/",
-    "name": "SamTV12345's Repository"
-  },
-  {
-    "url": "https://github.com/MattFaz/unraid_templates/",
-    "profile": "https://forums.unraid.net/profile/76145-mattfaz/",
-    "name": "MattFaz's Repository"
-  },
-  {
-    "url": "https://github.com/cloud-fs/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/261359-rotten-pagoda5238/",
-    "name": "rotten-pagoda5238's Repository"
-  },
-  {
-    "url": "https://github.com/sebastienvermeille/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/122183-sbeex/",
-    "name": "sbeex's Repository"
-  },
-  {
-    "url": "https://github.com/KodCloud-dev/unraid_template",
-    "profile": "https://forums.unraid.net/profile/255377-sealnado/",
-    "name": "sealnado's Repository"
-  },
-  {
-    "url": "https://github.com/xompage/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/262898-xompage/",
-    "name": "xompage's Repository"
-  },
-  {
-    "url": "https://github.com/EideardVMR/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/204759-eideard/",
-    "name": "Eideard's Repository"
-  },
-  {
-    "url": "https://github.com/asparon/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/96069-asparon/",
-    "name": "Asparon's Repository"
-  },
-  {
-    "url": "https://github.com/malkiebr/unraid-localtonet",
-    "profile": "https://forums.unraid.net/profile/234461-malkie/",
-    "name": "malkie's Repository"
-  },
-  {
-    "url": "https://github.com/mtrogman/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/115379-mtrogman/",
-    "name": "mtrogman's Repository"
-  },
-  {
-    "url": "https://github.com/alex-red/unraid-ca-templates",
-    "profile": "https://forums.unraid.net/profile/160581-alexred/",
-    "name": "AlexRed's Repository",
-    "duplicated": {
-        "dbgate/dbgate:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/soonic6/unraid-templates-ca",
-    "profile": "https://forums.unraid.net/profile/94002-sonic6/",
-    "name": "sonic6's Repository"
-  },
-  {
-    "url": "https://github.com/d3vyce/unraid-template",
-    "profile": "https://forums.unraid.net/profile/99205-d3vyce/",
-    "name": "d3vyce's Repository",
-    "duplicated": {
-        "lissy93/web-check": true
-    }
-  },
-  {
-    "url": "https://github.com/furritos/docker-templates",
-    "profile": "https://forums.unraid.net/profile/149001-deadfeet/",
-    "name": "DeadFeet's Repository"
-  },
-  {
-    "url": "https://github.com/alex3305/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/149439-alex3305/",
-    "name": "alex3305's Repository"
-  },
-  {
-    "url": "https://github.com/NightMeer/Unraid-Docker-Templates",
-    "profile": "https://forums.unraid.net/profile/191921-nightmeer/",
-    "name": "NightMeer's Repository"
-  },
-  {
-    "url": "https://github.com/dixtdf/templates",
-    "profile": "https://forums.unraid.net/profile/262846-dixtdf/",
-    "name": "dixtdf's Repository"
-  },
-  {
-    "url": "https://github.com/chirmstream/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/103420-dglb99/",
-    "name": "dglb99's Repository"
-  },
-  {
-    "url": "https://github.com/Phalcode/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/266495-phalcode/",
-    "name": "phalcode's Repository"
-  },
-  {
-    "url": "https://github.com/nylonee/watchlistarr-unraid",
-    "profile": "https://forums.unraid.net/profile/142159-nylonee/",
-    "name": "nylonee's Repository"
-  },
-  {
-    "url": "https://github.com/pallebone/UnifiUnraidReborn",
-    "profile": "https://forums.unraid.net/profile/100868-peteasking/",
-    "name": "PeteAsking's Repository"
-  },
-  {
-    "url": "https://github.com/EldonMcGuinness/UnraidCA",
-    "profile": "https://forums.unraid.net/profile/261788-eldonmcguinness/",
-    "name": "EldonMcGuiness' Repository"
-  },
-  {
-    "url": "https://github.com/Infotrend-Inc/OpenAI_WebUI",
-    "profile": "https://forums.unraid.net/profile/256461-iti/",
-    "name": "ITI's Repository"
-  },
-  {
-    "url": "https://github.com/BBergle/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/228849-bbergle/",
-    "name": "BBergle's Repository"
-  },
-  {
-    "url": "https://github.com/xiaodoudou/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/145775-xiaodoudou/",
-    "name": "Xiaodoudou's Repository"
-  },
-  {
-    "url": "https://github.com/PlazzmiK/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/268068-plazzmik/",
-    "name": "Plazzmik's Repository"
-  },
-  {
-    "url": "https://github.com/Core-i99/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/151311-core-i99/",
-    "name": "Core-i99's Repository"
-  },
-  {
-    "url": "https://github.com/Bobstin/willow-application-server",
-    "profile": "https://forums.unraid.net/profile/227361-bobstin/",
-    "name": "Bobstin's Repository"
-  },
-  {
-    "url": "https://github.com/ngfchl/ptools_unraid_template",
-    "profile": "https://forums.unraid.net/profile/268036-jacksonnie/",
-    "name": "JacksonNie's Repository"
-  },
-  {
-    "url": "https://github.com/Joly0/docker-templates",
-    "profile": "https://forums.unraid.net/profile/86760-joly0/",
-    "name": "joly0's Repository",
-    "duplicated": {
-        "ghcr.io/lodestone-team/lodestone_core": true
-    }
-  },
-  {
-    "url": "https://github.com/reloadfast/unraid_template_LibreLinkUp_Uploader",
-    "profile": "https://forums.unraid.net/profile/125005-guillermomg/",
-    "name": "GuillermoMG's Repository"
-  },
-  {
-    "url": "https://github.com/cross-seed/unraid-template",
-    "profile": "https://forums.unraid.net/profile/243161-ambipro/",
-    "name": "ambipro's Repository"
-  },
-  {
-    "url": "https://github.com/zakkarry/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/243161-ambipro/",
-    "name": "ambipro's Repository"
-  },
-  {
-    "url": "https://github.com/Donimax/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/266669-donimax/",
-    "name": "Donimax's Repository"
-  },
-  {
-    "url": "https://github.com/Droppisalt/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/229261-droppisalt/",
-    "name": "Droppisalt's Repository"
-  },
-  {
-    "url": "https://github.com/Infotrend-Inc/CTPO",
-    "name": "Infotrend Inc's Repository",
-    "profile": "https://forums.unraid.net/profile/256461-infotrend-inc/"
-  },
-  {
-    "url": "https://github.com/jnbarlow/unraid_templates",
-    "profile": "https://forums.unraid.net/profile/238964-john-barlow/",
-    "name": "John Barlow's Repository"
-  },
-  {
-    "url": "https://github.com/Phil-Barker/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/211519-philbarker/",
-    "name": "PhilBarker's Repository"
-  },
-  {
-    "url": "https://github.com/Eurotimmy/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/175441-eurotimmy/",
-    "name": "Eurotimmy's Repository",
-    "duplicated": {
-      "rommapp/romm:latest": true
-    }
-  },
-  {
-    "url": "https://github.com/MiranoVerhoef/Unraid-Mirano",
-    "profile": "https://forums.unraid.net/profile/96734-mirano/",
-    "name": "Mirano's Repository",
-    "duplicated": {
-        "dockurr/windows": true
-    }
-  },
-  {
-    "url": "https://github.com/bstottle/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/225-stottle/",
-    "name": "stottle's Repository"
-  },
-  {
-    "url": "https://github.com/UNRA1DUser/unraid-docker-templates",
-    "profile": "https://forums.unraid.net/profile/120631-unra1duser/",
-    "name": "UNRA1DUser's Repository",
-    "duplicated": {
-      "linuxserver/duckdns": true,
-      "jc21/nginx-proxy-manager": true,
-      "library/postgres": true,
-      "postgres": true,
-      "redis": true,
-      "tensorchord/pgvecto-rs:pg16-v0.2.1": true
-    }
-  },
-  {
-    "url": "https://github.com/0neTX/UnRAID_Template",
-    "profile": "https://forums.unraid.net/profile/161660-onetx/",
-    "name": "onetx's Repository"
-  },
-  {
-    "url": "https://github.com/disbedan015/nadekobotv4-unraid",
-    "profile": "https://forums.unraid.net/profile/115097-disbedan015/",
-    "name": "disbedan015's Repository"
-  },
-  {
-    "url": "https://github.com/ds-sebastian/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/238004-pureelectricity/",
-    "name": "pureelectricity's Repository"
-  },
-  {
-    "url": "https://github.com/nodiaque/unraid_template",
-    "profile": "https://forums.unraid.net/profile/147860-nodiaque/",
-    "name": "Nodiaque's Repository"
-  },
-  {
-    "url": "https://github.com/EMP83/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/271480-emp83/",
-    "name": "emp83's Repository",
-    "duplicated": {
-      "jc21/nginx-proxy-manager": true
-    }
-  },
-  {
-    "url": "https://github.com/mak-cs/unraid",
-    "profile": "https://forums.unraid.net/profile/269540-mak-cs/",
-    "name": "MAK-CS' Repository"
-  },
-  {
-    "url": "https://github.com/rezo552/unraid-ltfs/",
-    "profile": "https://forums.unraid.net/profile/271555-rezo552/",
-    "name": "ReZo552's Repository"
-  },
-  {
-    "url": "https://github.com/dgongut/UnRAID-Templates",
-    "profile": "https://forums.unraid.net/profile/250140-dgongut/",
-    "name": "dgongut's Repository"
-  },
-  {
-    "url": "https://github.com/jcoker85/UnraidTemplates",
-    "profile": "https://forums.unraid.net/profile/255902-jamxx/",
-    "name": "Jamxx's Repository"
-  },
-  {
-    "url": "https://github.com/Terebi42/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/252870-terebi/",
-    "name": "Terebi's Repository"
-  },
-  {
-    "url": "https://github.com/freeskier93/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/125013-dcooper/",
-    "name": "dcooper's Repository"
-  },
-  {
-    "url": "https://github.com/SasaKaranovic/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/273010-sasakaranovic/",
-    "name": "SasaKaranovic's Repository"
-  },
-  {
-    "url": "https://github.com/Lowess/docker-templates-unraid",
-    "profile": "https://forums.unraid.net/profile/161755-florian-dambrine/",
-    "name": "Florian Dambrine's Repository"
-  },
-  {
-    "url": "https://github.com/jgennari/UnraidApps",
-    "profile": "https://forums.unraid.net/profile/212091-joey-gennari/",
-    "name": "Joey Gennari's Repository"
-  },
-  {
-    "url": "https://github.com/AronMarinelli/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/126179-aronm/",
-    "name": "AronM's Repository"
-  },
-  {
-    "url": "https://github.com/kieraneglin/unraid_ca",
-    "profile": "https://forums.unraid.net/profile/185979-kieran-e/",
-    "name": "Kieran E's Repository"
-  },
-  {
-    "url": "https://github.com/tschoerk/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/273668-tschoerk/",
-    "name": "tschoerk's Repository"
-  },
-  {
-    "url": "https://github.com/fdm-monster/fdm-monster-unraid",
-    "profile": "https://forums.unraid.net/profile/124887-davidzwa/",
-    "name": "davidzwa's Repository"
-  },
-  {
-    "url": "https://github.com/NebN/unraid-apps",
-    "profile": "https://forums.unraid.net/profile/274578-nebn/",
-    "name": "NebN's Repository"
-  },
-  {
-    "url": "https://github.com/gbendy/unraid-templates",
-    "profile": "https://forums.unraid.net/profile/275025-bendy/",
-    "name": "bendy's Repository"
-  }
+	{
+		"url": "https://github.com/snuffomega/docker_unraid_templates",
+		"name": "snuffomega's Repository",
+		"profile": "https://forums.unraid.net/profile/258583-snuffomega/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/laurensguijt/unraid-templates",
+		"name": "Laurensguijt's Repository",
+		"profile": "https://forums.unraid.net/profile/254983-laurensguijt/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/neur0map/deskmon-unraid-templates",
+		"name": "Neur0map's Repository",
+		"profile": "https://forums.unraid.net/profile/294130-neur0map/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/mayo-248/unraid-templates",
+		"name": "Mayo_248's Repository",
+		"profile": "https://forums.unraid.net/profile/175387-mayo_248/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/davidjkling/unraid-templates",
+		"name": "Kling's Repository",
+		"profile": "https://forums.unraid.net/profile/293102-kling/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/gibz104/SpoolmanSync",
+		"name": "gibz104's Repository",
+		"profile": "https://forums.unraid.net/profile/293978-gibz104/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/ghzgod/signal-notification-unraid",
+		"name": "ghzgod11's Repository",
+		"profile": "https://forums.unraid.net/profile/293977-ghzgod11/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/caddickzac/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/293796-zcaddick/",
+		"name": "zcaddick's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/TorBox-App/unraid-templates",
+		"name": "Wamy's Repository",
+		"profile": "https://forums.unraid.net/profile/247536-wamy/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/Saetron/unRAID-CA-templates",
+		"name": "saetron's Repository",
+		"profile": "https://forums.unraid.net/profile/290584-saetron/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/johnpwhite/unraid-community-applications-index",
+		"name": "johner's Repository",
+		"profile": "https://forums.unraid.net/profile/5686-johner/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/kikootwo/ReadMeABook",
+		"name": "ReadMeABook's Repository",
+		"profile": "https://forums.unraid.net/profile/293929-kikootwo/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/mccann6/unraid-templates/",
+		"name": "mccann6's Repository",
+		"profile": "https://forums.unraid.net/profile/293805-mccann6/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Petelombardo/unraid-templates",
+		"name": "Pete L's Repository",
+		"profile": "https://forums.unraid.net/profile/293917-pete-l/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/medzin/docker-templates",
+		"name": "medzin's Repository",
+		"profile": "https://forums.unraid.net/profile/293048-medzin/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/MrCorehh/unraid-templates",
+		"name": "MrCorehh's Repository",
+		"profile": "https://forums.unraid.net/profile/293911-mrcorehh/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/Watso4183/Unraid",
+		"name": "AcmePluto's Repository",
+		"profile": "https://forums.unraid.net/profile/293586-acmepluto/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/AradD7/lightarr-template-files",
+		"name": "Arad's Repository",
+		"profile": "https://forums.unraid.net/profile/293896-arad",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/liorbass/tandarr-unraid-templates",
+		"name": "LioirBass' Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/dervish666/unraid-templates",
+		"name": "dervish's Repository",
+		"profile": "https://forums.unraid.net/profile/179627-dervish/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/davemachado/unraid-templates",
+		"name": "drm's Repository",
+		"profile": "https://forums.unraid.net/profile/291782-drm8/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/softerfish/seekandwatch",
+		"name": "tenletter's Repository",
+		"profile": "https://forums.unraid.net/profile/283725-tenletters/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/fccview/unraid-templates",
+		"name": "fccview's Repository",
+		"profile": "https://forums.unraid.net/profile/293085-fccview/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/jessielw/unraid-templates",
+		"name": "Jessielw's Repository",
+		"profile": "https://forums.unraid.net/profile/201686-jessielw/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/nebula-codes/hytale_server_manager",
+		"name": "Nebula's Repository",
+		"profile": "https://forums.unraid.net/profile/293434-nebulacodes/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/CaptainPimpJr/Unraid-Community-Applications",
+		"name": "CaptainPimpJr's Repository",
+		"profile": "https://forums.unraid.net/profile/271177-cptpimpjunior/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Maikboarder/Playerr",
+		"name": "Maikboarder's Repository",
+		"profile": "https://forums.unraid.net/profile/293293-maikboarder/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/gthrift/gthrift-unraid-ca",
+		"name": "gthrift's Repository",
+		"profile": "https://forums.unraid.net/profile/293215-gthrift/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/MattyStacks/docker-templates",
+		"name": "MattyStacks's Repository",
+		"profile": "https://forums.unraid.net/profile/9036-mattystacks/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/Yusseiin/unraid-templates",
+		"name": "Yusseiin's Repository",
+		"profile": "https://forums.unraid.net/profile/279816-yusseiin/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/cabi24/notenregal",
+		"name": "cabi24's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/schartrand77/mkw2",
+		"name": "schartrand77's Repository",
+		"profile": "https://forums.unraid.net/profile/180557-schartrand77/",
+		"communication": "discord"
+	},
+	{
+		"name": "snoopy86's Repository",
+		"url": "https://github.com/devdems/unraid",
+		"forum": "http://lime-technology.com/forum/index.php?topic=43610.0",
+		"profile": "https://forums.unraid.net/profile/26537-snoopy86/"
+	},
+	{
+		"url": "https://github.com/orangecoding/fredy-unraid-template",
+		"name": "Orangecoding's Repository",
+		"profile": "https://forums.unraid.net/profile/292517-orangecoding/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/jandrop/file_core_api_unraid",
+		"name": "jandrop's Repository",
+		"profile": "https://forums.unraid.net/profile/111434-jandrop/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/connorgallopo/tracearr-unraid-template",
+		"name": "Gallapagos' Repository",
+		"profile": "https://forums.unraid.net/profile/281348-gallapagos/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/Indemnity83/always-bring-a-gift",
+		"name": "Indemnity83's Repository",
+		"profile": "https://forums.unraid.net/profile/83781-indemnity83/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/keenaanee/CinemaStatus",
+		"name": "Keenaanee's Repository",
+		"profile": "https://forums.unraid.net/profile/271535-keenaanee/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/JFLXCLOUD/NeXroll",
+		"name": "NeXroll's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/jlightner86/jellylooter",
+		"name": "ThePizzaNinja86's Repository",
+		"profile": "https://forums.unraid.net/profile/287631-thepizzaninja86/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/anym001/unraid-docker-templates",
+		"name": "Anym001's Repository",
+		"profile": "https://forums.unraid.net/profile/119296-anym001/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/vincentmakes/cv-manager",
+		"name": "vincentmakes' Repository",
+		"profile": "https://forums.unraid.net/profile/292228-vincentmakes/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/kurrier-org/kurrier",
+		"name": "debuggy12's Repository",
+		"profile": "https://forums.unraid.net/profile/292187-debuggy12/",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/WuSiYu/unraid-ca-xml/",
+		"name": "Wu23333's Repository",
+		"profile": "https://forums.unraid.net/profile/175574-wu23333/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/murtaza-nasir/speakr-unraid",
+		"name": "learnedmachine's Repository",
+		"profile": "https://github.com/murtaza-nasir/speakr-unraid",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/sftpmalin/Media-Remote-Convert",
+		"name": "SftpMalin FFmpeg's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/DevlinDelFuego/unraid-templates",
+		"name": "DevlinDelFuego's Repository",
+		"profile": "https://forums.unraid.net/profile/287879-devlindelfuego/",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/ruaan-deysel/unraid-management-agent",
+		"name": "PanicMechanic00's Repository",
+		"profile": "https://forums.unraid.net/profile/98076-panicmechanic007/",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/theodorecharles/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/103598-paloooz/",
+		"name": "paloooz's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/m3ue/m3u-editor",
+		"profile": "https://forums.unraid.net/profile/292018-shparkison/",
+		"name": "shparikson's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/T4s3rF4c3/macreplay_v2",
+		"profile": "https://forums.unraid.net/profile/150938-t4s3rf4c3/",
+		"name": "T4s3rF4c3's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/carrotwaxr/peek-stash-browser",
+		"profile": "https://forums.unraid.net/profile/291876-carrot-waxxr/",
+		"name": "Carrot Waxxr's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/NickBootOne/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/93263-nickboot/",
+		"name": "nickboot's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/untraceablez/unraid-apps/",
+		"profile": "https://forums.unraid.net/profile/111430-untraceablez/",
+		"name": "untraceablez's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/kroeberd/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/291694-sarcasm/",
+		"name": "sarcasm's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/BabaBooey84/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/7743-uderzo/",
+		"name": "Uderzo's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/mbirnbach/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/291521-mbirnbach/",
+		"name": "mbirnbach's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/N85UK/UNRAID_APP",
+		"profile": "https://forums.unraid.net/profile/109185-paulmccannn85uk/",
+		"name": "N85UK's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/cajuncoding/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/134398-cajuncoding/",
+		"name": "CajunCoding's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/buxxdev/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/291279-mbxy/",
+		"name": "buxxdev's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/netpersona/popcorn-unraid",
+		"profile": "https://forums.unraid.net/profile/234637-smackmybones/",
+		"name": "Netpersona's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/dopeytree/Unraid-templates",
+		"profile": "https://forums.unraid.net/profile/183052-dopeytree/",
+		"name": "dopeytree's Repository",
+		"communication": "forum"
+	},
+	{
+		"name": "Dynamix Plugin Repository",
+		"url": "https://github.com/unraid/dynamix-plugins-xml",
+		"forum": "http://lime-technology.com/forum/index.php?topic=36543.0",
+		"profile": "https://forums.unraid.net/profile/2736-bonienl/"
+	},
+	{
+		"name": "Dynamix Repository",
+		"url": "https://github.com/bergware/dynamix-plugins",
+		"forum": "http://lime-technology.com/forum/index.php?topic=36543.0",
+		"profile": "https://forums.unraid.net/profile/2736-bonienl/",
+		"hideFromCA": {
+			"https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.encryption.key.plg": true,
+			"https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.factory.reset.plg": true,
+			"https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.safe.mode.plg": true,
+			"https://raw.github.com/unraid/dynamix/master/unRAIDv6/dynamix.share.floor.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.active.streams.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.cache.dirs.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.date.time.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.day.night.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.file.integrity.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.file.manager.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.local.master.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.password.validator.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.s3.sleep.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.schedules.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.scsi.devices.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.ssd.trim.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.stop.shell.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.autofan.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.buttons.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.info.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.stats.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.system.temp.plg": true,
+			"https://raw.githubusercontent.com/unraid/dynamix/master/unRAIDv6/dynamix.wireguard.plg": true,
+			"https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.encryption.key.plg": true,
+			"https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.factory.reset.plg": true,
+			"https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.safe.mode.plg": true,
+			"https://raw.github.com/bergware/dynamix/master/unRAIDv6/dynamix.share.floor.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.active.streams.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.cache.dirs.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.date.time.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.day.night.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.file.integrity.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.file.manager.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.local.master.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.password.validator.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.s3.sleep.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.schedules.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.scsi.devices.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.ssd.trim.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.stop.shell.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.autofan.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.buttons.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.info.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.stats.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.system.temp.plg": true,
+			"https://raw.githubusercontent.com/bergware/dynamix/master/unRAIDv6/dynamix.wireguard.plg": true
+		}
+	},
+	{
+		"url": "https://github.com/rschuiling/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/261141-emphyrio/",
+		"name": "Emphyrio's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/bigsing/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/7676-bigsing/",
+		"name": "bigsing's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/xxBeanSproutxx/unraid-docling-ca",
+		"profile": "https://forums.unraid.net/profile/288925-bean_sprout/",
+		"name": "xxBeanSproutxx's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Shaneee/system-monitor",
+		"profile": "https://forums.unraid.net/profile/290974-shaneee92/",
+		"name": "Shaneee's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Pa7rickStar/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/288616-pa7rickstar/",
+		"name": "Pa7ricstar's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/afairgiant/MediKeep_unraid",
+		"profile": "https://forums.unraid.net/profile/116260-afairgiant/",
+		"name": "afairgiant's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/thedinz/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/145818-thedinz/",
+		"name": "thedinz' Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/framedr0p/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/290788-framedr0p/",
+		"name": "framdr0p's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Skylinar/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/109199-skylinar/",
+		"name": "Skylinar's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/undead-reaper/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
+		"name": "Undead Reaper's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/egnerdata/unraid-docker-template-papra",
+		"profile": "https://forums.unraid.net/profile/274607-egnerdata/",
+		"name": "Egnerdata's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/RoBro92/fanbridge-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/290531-robro92/",
+		"name": "RoBro92's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/jjermany/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/288757-jermcee/",
+		"name": "jermcee's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/mlapaglia/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/100043-mlapaglia/",
+		"name": "mlapaglia's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/slamanna212/UnraidTemplates",
+		"profile": "https://forums.unraid.net/profile/106550-slamanna212/",
+		"name": "slamanna212's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/drewzh/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/266696-abreast-statesman5405/",
+		"name": "abreast-statesman5405's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/MitchellThompkins/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/285040-not_a_real_human/",
+		"name": "not_a_real_human's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/benjaminRoberts01375/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/290281-preposterous/",
+		"name": "Preposterous' Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/GEngines/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/290261-bmetpally/",
+		"name": "GEngines' Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/BryanGoble/docker-templates",
+		"profile": "https://forums.unraid.net/profile/290235-bgubs/",
+		"name": "bgubs' Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/cleao01/UnraidDockerTemplates",
+		"profile": "https://forums.unraid.net/profile/123530-cab%C3%A9/",
+		"name": "Cab\u00e9's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Twingate-Community/unraid-template",
+		"profile": "https://forums.unraid.net/profile/289418-twingate-andrewb/",
+		"name": "Twingate Community's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/rohit-purandare/ShelfBridge-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/283015-rpurandare/",
+		"name": "rpurandare's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/T-Eberle/unraid-community-apps",
+		"profile": "https://forums.unraid.net/profile/289970-tommy_e/",
+		"name": "Tommy_E's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/cameron581/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/253440-cameron581/",
+		"name": "Cameron581's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Zuerrex/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/234570-zuerrex/",
+		"name": "zuerrex's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/secretlycarl/onboarderr-unraid",
+		"profile": "https://forums.unraid.net/profile/289747-secretlycarl/",
+		"name": "SecretlyCarl's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/tajniak81/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/98215-tajniak81/",
+		"name": "Tajniak81's Repository",
+		"communication": "forum "
+	},
+	{
+		"url": "https://github.com/catapultcase/Unraid_CommunityApplications",
+		"profile": "https://forums.unraid.net/profile/83669-rusty6285/",
+		"name": "Rusty6285's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Cleanuparr/unraid",
+		"profile": "https://forums.unraid.net/profile/282380-flamin/",
+		"name": "Flamin's Repository",
+		"communication:": "discord"
+	},
+	{
+		"url": "https://github.com/OctoEverywhere/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/289064-quinninator/",
+		"name": "Quinninator's Repository",
+		"communication:": "email"
+	},
+	{
+		"url": "https://github.com/ObviousViking/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/114882-obviousviking/",
+		"name": "ObviousViking's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/jo-sobo/scriptlogs-unraid-plugin",
+		"profile": "https://forums.unraid.net/profile/120452-magnum308/",
+		"name": "Magnum.308's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/warwickschroeder/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/103842-syknight/",
+		"name": "Syknight's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/soitora/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/282682-soitora/",
+		"name": "Soitora's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/gameyfin/unraid",
+		"profile": "https://forums.unraid.net/profile/249165-grimsi/",
+		"name": "grimsi's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/CordlessWool/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/289062-cordlesswool/",
+		"name": "CordlessWool's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/tophat17/jelly-request",
+		"profile": "https://forums.unraid.net/profile/172432-tophat17/",
+		"name": "TopHat17's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/acidrs03/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/125556-acidrs/",
+		"name": "Acidrs' Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/ajb3932/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/276974-ajb3932/",
+		"name": "ajb3932's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/RobertCajun/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/285092-robertcajun/",
+		"name": "RobertCajun's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/alyssaholland99/unraid-immich-tiktok-remover",
+		"profile": "https://forums.unraid.net/profile/289132-alyssaholland/",
+		"name": "AlyssaHolland's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/strike84/DiskSpaceManagement-template",
+		"profile": "https://forums.unraid.net/profile/63311-strike/",
+		"name": "strike's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/jcofer555/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/135547-jcofer555/",
+		"name": "jcofer555's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/ck9393/fanctrlplus",
+		"profile": "https://forums.unraid.net/profile/242702-ckchong/",
+		"name": "ck9393's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/DearTanker/Unraid-Docker-Template",
+		"profile": "https://forums.unraid.net/profile/98483-deartanker/",
+		"name": "DearTanker's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Gill-Bates/unraid-app-templates",
+		"profile": "https://forums.unraid.net/profile/288881-gillbates/",
+		"name": "GillBates' Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/NickBorgers/unraid-apps",
+		"profile": "https://forums.unraid.net/profile/69750-nickborgers/",
+		"name": "Nick Borgers' Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/Kurotaku-sama/Unraid-Plugins-Repository",
+		"profile": "https://forums.unraid.net/profile/277881-kurotaku/",
+		"name": "Kurotaku's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/Cirx08/Unraid",
+		"profile": "https://forums.unraid.net/profile/288718-cirx08/",
+		"name": "Cirx08's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/yannisalexiou/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/283014-yannisalexiou/",
+		"name": "Docked by Yannis' Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/silkyclouds/PMDA_unraid_xml",
+		"profile": "https://forums.unraid.net/profile/170800-meaning/",
+		"name": "PMDA's Repository",
+		"communication": "discord"
+	},
+	{
+		"url": "https://github.com/mediux-team/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/125333-mmoosem/",
+		"name": "Mediux-Team's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/misterjtc/docker-templates",
+		"profile": "https://forums.unraid.net/profile/68425-misterjtc/",
+		"name": "Misterjtc's Repository",
+		"communication": "forum"
+	},
+	{
+		"url": "https://github.com/alexycodes/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/288438-alexycodes/",
+		"name": "Alexy's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/desertwitch/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/115350-rysz/",
+		"name": "Rysz's Repository"
+	},
+	{
+		"url": "https://github.com/Michuelnik/docker-mediathekview-web",
+		"profile": "https://forums.unraid.net/profile/153213-revan335/",
+		"name": "Reven335's Repository"
+	},
+	{
+		"url": "https://github.com/Bovive/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/259292-bovive/",
+		"name": "Bovive's Repository"
+	},
+	{
+		"url": "https://github.com/AnimaI/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126104-d0ooo/",
+		"name": "D0ooo's Repository"
+	},
+	{
+		"url": "https://github.com/mackid1993/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/74622-mackid1993/",
+		"name": "Mackid1993's Repository"
+	},
+	{
+		"url": "https://github.com/celsian/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/120837-celsian/",
+		"name": "Celsian's Repository"
+	},
+	{
+		"url": "https://github.com/EddCase/unRAID_Templates",
+		"profile": "https://forums.unraid.net/profile/10833-eddcase/",
+		"name": "EddCase's Repository"
+	},
+	{
+		"url": "https://github.com/googleg/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/282598-googleg/",
+		"name": "googleg's Repository"
+	},
+	{
+		"url": "https://github.com/AnimaI/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126104-d0ooo/",
+		"name": "d0ooo's Repository"
+	},
+	{
+		"url": "https://github.com/TorBox-App/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/247536-wamy/",
+		"name": "Wamy's Repository"
+	},
+	{
+		"url": "https://github.com/dkeners/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/287661-dkeners/",
+		"name": "dkeners' Repository"
+	},
+	{
+		"url": "https://github.com/jamcalli/pulsarr-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/286940-sp00ks/",
+		"name": "sp00ks' Repository"
+	},
+	{
+		"url": "https://github.com/itsnotashley/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/287054-itsnotashley/",
+		"name": "itsnotashley's Repository"
+	},
+	{
+		"url": "https://github.com/andrejwithj/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/168139-fancyshmancy/",
+		"name": "fancyshmancy's Repository"
+	},
+	{
+		"url": "https://github.com/VladoPortos/vladoportos-unraid-xml",
+		"profile": "https://forums.unraid.net/profile/103082-vladoportos/",
+		"name": "VladoPortos' Repository"
+	},
+	{
+		"url": "https://github.com/MorgothRB/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/280956-morgoth/",
+		"name": "Morgoth's Repository"
+	},
+	{
+		"url": "https://github.com/jl94x4/ColleXions",
+		"profile": "https://forums.unraid.net/profile/270097-thatja/",
+		"name": "thatja's Repository"
+	},
+	{
+		"url": "https://github.com/theweebcoders/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/146571-tim000x3/",
+		"name": "tim000x3's Repository"
+	},
+	{
+		"url": "https://github.com/glls/Docker-Templates-Unraid",
+		"profile": "https://forums.unraid.net/profile/272335-glls/",
+		"name": "glls' Repository"
+	},
+	{
+		"url": "https://github.com/damongolding/immich-kiosk-unraid",
+		"profile": "https://forums.unraid.net/profile/285555-damongolding/",
+		"name": "DamonGolding's Repository"
+	},
+	{
+		"url": "https://github.com/eibex/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/268287-eibe/",
+		"name": "Eibe's Repository"
+	},
+	{
+		"url": "https://github.com/JZomDev/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/159615-zguilt/",
+		"name": "zguilt's Repository"
+	},
+	{
+		"url": "https://github.com/justjoseorg/Unraid-Intel_Ollama",
+		"profile": "https://forums.unraid.net/profile/261082-possessive-small6053/",
+		"name": "progressive-small6053's Repository"
+	},
+	{
+		"url": "https://github.com/SCUR0/Unraid_Docker_Locust",
+		"profile": "https://forums.unraid.net/profile/274107-scuro/",
+		"name": "Scuro's Repository"
+	},
+	{
+		"url": "https://github.com/robotfishe/robotfishe-unraid-apps",
+		"profile": "https://forums.unraid.net/profile/204504-robotfishe/",
+		"name": "robotfishe's Repository"
+	},
+	{
+		"url": "https://github.com/Eksistenze/unraidtemplates",
+		"profile": "https://forums.unraid.net/profile/153955-eksistenze/",
+		"name": "Eksistenze's Repository"
+	},
+	{
+		"url": "https://github.com/xshatterx/Seraphys",
+		"profile": "https://forums.unraid.net/profile/275245-seraphys/",
+		"name": "Seraphys' Repository"
+	},
+	{
+		"url": "https://github.com/stefan-matic/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/269247-fallen94/",
+		"name": "Fallen94's Repository"
+	},
+	{
+		"url": "http://github.com/RiDDiX/uraid-templates",
+		"profile": "https://forums.unraid.net/profile/123957-riddix/",
+		"name": "RiDDiX's Repository"
+	},
+	{
+		"url": "https://github.com/NicolasHaas/unraid-xml-templates",
+		"profile": "https://forums.unraid.net/profile/110262-twixii/",
+		"name": "Twixii's Repository"
+	},
+	{
+		"url": "https://github.com/guniv/unraid-ca-apps",
+		"profile": "https://forums.unraid.net/profile/178712-guniv/",
+		"name": "guniv's Repository"
+	},
+	{
+		"url": "https://github.com/RafaelCenzano/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/171730-cenzar/",
+		"name": "cenzar's Repository"
+	},
+	{
+		"url": "https://github.com/timespacedecay/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/121604-lostinspace/",
+		"name": "lostinspace's Repository"
+	},
+	{
+		"url": "https://github.com/mcreekmore/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/216090-mcreekmore/",
+		"name": "mcreekmore's Repository"
+	},
+	{
+		"url": "https://github.com/mash2k3/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/265722-mash2k3/",
+		"name": "mash2k3's Repository"
+	},
+	{
+		"url": "https://github.com/ctrlaltd1337ed/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/84709-ctrlaltd1337/",
+		"name": "ctrlaltd1337's Repository"
+	},
+	{
+		"url": "https://github.com/vwdewaal/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/145081-vannie78/",
+		"name": "vannie78's Repository"
+	},
+	{
+		"url": "https://github.com/TheMapledCog/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/168586-campu0999/",
+		"name": "campu0999's Repository"
+	},
+	{
+		"url": "https://github.com/error311/UNRAID_COMMUNITY_APPS",
+		"profile": "https://forums.unraid.net/profile/207982-error311/",
+		"name": "error311's Repository"
+	},
+	{
+		"url": "https://github.com/TheBinaryNinja/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/103361-iflip721/",
+		"name": "i.Flip721's Repository"
+	},
+	{
+		"url": "https://github.com/jterpstra1/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/92505-jterpstra/",
+		"name": "jterpstra's Repository"
+	},
+	{
+		"url": "https://github.com/Maitresinh/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/280760-logan23/",
+		"name": "logan23's Repository"
+	},
+	{
+		"url": "https://github.com/damongolding/immich-kiosk-unraid",
+		"profile": "https://forums.unraid.net/profile/285555-damongolding/",
+		"name": "DamonGolding's Repository"
+	},
+	{
+		"url": "https://github.com/oromis995/UnraidKoboldCpp",
+		"profile": "https://forums.unraid.net/profile/108450-oromis95/",
+		"name": "oromis95's Repository"
+	},
+	{
+		"url": "https://github.com/b3rrytech/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/11610-b3rrytech/",
+		"name": "b3rrytech's Repository"
+	},
+	{
+		"url": "https://github.com/olilanz/unraid-templates/",
+		"profile": "https://forums.unraid.net/profile/175858-boomshakalaka/",
+		"name": "boomshakala's Repository"
+	},
+	{
+		"url": "https://github.com/Krillsson/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/285387-krillsson/",
+		"name": "Krillsson's Repository"
+	},
+	{
+		"url": "https://github.com/SnuK87/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/285383-snuk/",
+		"name": "Snuk's Repository"
+	},
+	{
+		"url": "https://github.com/crgodfrey/unraid-froggi",
+		"profile": "https://forums.unraid.net/profile/274467-monkeyss/",
+		"name": "monkeyss' Repository"
+	},
+	{
+		"url": "https://github.com/eulaly/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/99159-dealbakerjones/",
+		"name": "dealbakerjones' Repository"
+	},
+	{
+		"url": "https://github.com/clairekardas/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/269754-anna/",
+		"name": "anna's Repository"
+	},
+	{
+		"url": "https://github.com/XeXSolutions/unraid-stats",
+		"profile": "https://forums.unraid.net/profile/165045-xexsolutions/",
+		"name": "XeXSolutions' Repository"
+	},
+	{
+		"url": "https://github.com/Piratkopia13/unraid-buddybackup",
+		"profile": "https://forums.unraid.net/profile/158066-pirat/",
+		"name": "Pirat's Repository"
+	},
+	{
+		"url": "https://github.com/swiss01/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/96834-swiss01/",
+		"name": "swiss01's Repository"
+	},
+	{
+		"url": "https://github.com/cmoro-deusto/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/284950-cmoro-gondor/",
+		"name": "cmoro-gondor's Repository"
+	},
+	{
+		"url": "https://github.com/sam10155/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/116626-sam10155/",
+		"name": "sam10155's Repository"
+	},
+	{
+		"url": "https://github.com/swiss01/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/96834-swiss01/",
+		"name": "swiss01's Repository"
+	},
+	{
+		"url": "https://github.com/ltdstudio/MoviePilot_unraid_CA",
+		"profile": "https://forums.unraid.net/profile/284198-doudou1234/",
+		"name": "doudou1234's Repository"
+	},
+	{
+		"url": "https://github.com/NSPManager/NSPanelManager",
+		"profile": "https://forums.unraid.net/profile/122183-sbeex/",
+		"name": "sbeex's Repository"
+	},
+	{
+		"url": "https://github.com/xshatterx/Seraphys",
+		"profile": "https://forums.unraid.net/profile/275245-seraphys/",
+		"name": "Seraphys' Repository"
+	},
+	{
+		"url": "https://github.com/JourneyDocker/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/284186-journeyover/",
+		"name": "JourneyOver's Repository"
+	},
+	{
+		"url": "https://github.com/fejich/unRAID-plugins-templates",
+		"profile": "https://forums.unraid.net/profile/122412-fejich/",
+		"name": "fejich's Repository"
+	},
+	{
+		"url": "https://github.com/UnToobed/Unraid-Docker-Templates",
+		"profile": "https://forums.unraid.net/profile/160182-unusmundus/",
+		"name": "UnusMundus' Repository"
+	},
+	{
+		"url": "https://github.com/fosrl/templates",
+		"profile": "https://forums.unraid.net/profile/96141-milo-schwartz/",
+		"name": "Fossorial's Repository",
+		"duplicated": {
+			"traefik:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/jarvis2f/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/284045-jarvis2f/",
+		"name": "jarvis2f's Repository"
+	},
+	{
+		"url": "https://github.com/jjdenhertog/spotify-to-plex-unraid",
+		"profile": "https://forums.unraid.net/profile/283509-jjdenhertog/",
+		"name": "jjdenhertog's Repository"
+	},
+	{
+		"url": "https://github.com/bghizzy/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/268319-bg_hizzy/",
+		"name": "bg_hizzy's Repository"
+	},
+	{
+		"url": "https://github.com/Teknicallity/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/170368-teknicallity/",
+		"name": "Teknicallity's Repository"
+	},
+	{
+		"url": "https://github.com/smoores-dev/storyteller-unraid",
+		"profile": "https://forums.unraid.net/profile/144985-smoores/",
+		"name": "smoores' Repository"
+	},
+	{
+		"url": "https://github.com/kuroki-kael/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/283413-tatseo/",
+		"name": "tatseo's Repository"
+	},
+	{
+		"url": "https://github.com/Mainfrezzer/UnRaid-Templates/",
+		"profile": "https://forums.unraid.net/profile/201895-mainfrezzer/",
+		"name": "Mainfrezzer's Repository"
+	},
+	{
+		"url": "https://github.com/Receipt-Wrangler/receipt-wrangler-unraid",
+		"profile": "https://forums.unraid.net/profile/268018-wrangler/",
+		"name": "wrangler's Repository"
+	},
+	{
+		"url": "https://github.com/TypingPenguin/docker-templates",
+		"profile": "https://forums.unraid.net/profile/283235-typingpenguin/",
+		"name": "TypingPenguin's Repository"
+	},
+	{
+		"url": "https://github.com/hhftechnology/unraid_app_templates",
+		"profile": "https://forums.unraid.net/profile/282959-hhftechnology/",
+		"name": "hhftechnology's Repository",
+		"duplicated": {
+			"donetick/donetick": true
+		}
+	},
+	{
+		"url": "https://github.com/undead-reaper/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/283186-dharam-soni/",
+		"name": "Dharam Soni's Repository"
+	},
+	{
+		"url": "https://github.com/masterjb/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/124596-human-126094/",
+		"name": "Human-126094's Repository"
+	},
+	{
+		"url": "https://github.com/jcesclapez/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/280038-darklesc/",
+		"name": "Darklesc's Repository"
+	},
+	{
+		"url": "https://github.com/carroarmato0/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169872-carroarmato0/",
+		"name": "carroarmato0's Repository"
+	},
+	{
+		"url": "https://github.com/matda59/video-to-mp3-converter",
+		"profile": "https://forums.unraid.net/profile/119423-matda59/",
+		"name": "matda59's Repository"
+	},
+	{
+		"url": "https://github.com/Staffwerke/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/248178-staffwerke-gmbh/",
+		"name": "Staffwerke GmbH's Repository"
+	},
+	{
+		"url": "https://github.com/tommyvange/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/282469-tommyvange/",
+		"name": "tommyvange's Repository"
+	},
+	{
+		"url": "https://github.com/MROGHUB/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/282192-mackattack/",
+		"name": "MackAttack's Repository"
+	},
+	{
+		"url": "https://github.com/7eventy7/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/279422-7eventy7/",
+		"name": "7eventy7's Repository"
+	},
+	{
+		"url": "https://github.com/ikoyhn/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/128240-ikoyhn/",
+		"name": "ikoyhn's Repository"
+	},
+	{
+		"url": "https://github.com/hofq/docker-templates",
+		"profile": "https://forums.unraid.net/profile/112121-kippenhof/",
+		"name": "Kippenhof's Repository"
+	},
+	{
+		"url": "https://github.com/bmartino1/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/118010-bmartino1/",
+		"name": "bmartino1's Repository",
+		"communication": "email"
+	},
+	{
+		"url": "https://github.com/jcesclapez/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/280038-darklesc/",
+		"name": "Darklesc's Repository"
+	},
+	{
+		"url": "https://github.com/Aquillacomputingsystem/unraid-templetes",
+		"profile": "https://forums.unraid.net/profile/86880-alphacosmos/",
+		"name": "Alphacosmos' Repository"
+	},
+	{
+		"url": "https://github.com/Groestlcoin/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/281950-groestlcoin/",
+		"name": "groestlcoin's Repository"
+	},
+	{
+		"url": "https://github.com/jordan-dalby/unraidtemplates",
+		"profile": "https://forums.unraid.net/profile/281718-data-jordan/",
+		"name": "data-jordan's Repository"
+	},
+	{
+		"url": "https://github.com/giuseppe99barchetta/SuggestArr",
+		"profile": "https://forums.unraid.net/profile/281768-ciuse99/",
+		"name": "ciuse99's Repository",
+		"duplicated": {
+			"ciuse99/suggestarr:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/logandwaters/Plug-and-Play-Docker",
+		"profile": "https://forums.unraid.net/profile/281787-lwater/",
+		"name": "lwater's Repository"
+	},
+	{
+		"url": "https://github.com/apfaffman/docker-templates",
+		"profile": "https://forums.unraid.net/profile/223909-apfaffman/",
+		"name": "apfaffman's Repository"
+	},
+	{
+		"url": "https://github.com/andaks/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/114400-andaks/",
+		"name": "andaks' Repository"
+	},
+	{
+		"url": "https://github.com/GotAnAccount/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/187798-simpleserver/",
+		"name": "simpleServer's Repository"
+	},
+	{
+		"url": "https://github.com/soultaco83/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/87407-soultaco83/",
+		"name": "soultaco83's Repository"
+	},
+	{
+		"url": "https://github.com/D3lta/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/281050-decrevi/",
+		"name": "decrevi's Repository"
+	},
+	{
+		"url": "https://github.com/gjhami/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/281298-raidingunraid/",
+		"name": "raidingUnraid's Repository"
+	},
+	{
+		"url": "https://github.com/ne0ark/docker-templates",
+		"profile": "https://forums.unraid.net/profile/221895-naidu/",
+		"name": "Naidu's Repository"
+	},
+	{
+		"url": "https://github.com/feederbox826/unraid-templates",
+		"name": "feederbox826's Repository",
+		"profile": "https://forums.unraid.net/profile/281190-feederbox826/"
+	},
+	{
+		"url": "https://github.com/dkaser/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/244077-edacerton/",
+		"name": "EDACerton's Repository"
+	},
+	{
+		"url": "https://github.com/phyzical/UnraidPlugins",
+		"profile": "https://forums.unraid.net/profile/97031-phyzical/",
+		"name": "phyzical's Repository"
+	},
+	{
+		"url": "https://github.com/zip-fa/unraid-torrserver",
+		"profile": "https://forums.unraid.net/profile/280443-unraidnewbie2211/",
+		"name": "UnraidNewbie2211's Repository",
+		"duplicated": {
+			"ghcr.io/yourok/torrserver": true
+		}
+	},
+	{
+		"url": "https://github.com/Unlearned6688/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/170061-unjustice/",
+		"name": "UnJustice's Repository"
+	},
+	{
+		"url": "https://github.com/DavidWJR/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/253276-reggieswag/",
+		"name": "ReggieSwag's Repository"
+	},
+	{
+		"url": "https://github.com/mmartial/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/15ho4534-martial/",
+		"name": "martial's Repository"
+	},
+	{
+		"url": "https://github.com/rommapp/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/279632-arcaneasada/",
+		"name": "arcanesada's Repository"
+	},
+	{
+		"url": "https://github.com/Cobbert/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/129102-cobb/",
+		"name": "cobb's Repository"
+	},
+	{
+		"url": "https://github.com/Cyberschorsch/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/279951-cyberschorsch/",
+		"name": "Cyberschorsch's Repository"
+	},
+	{
+		"url": "https://github.com/Schaka/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/243152-schaka/",
+		"name": "Schaka's Repository"
+	},
+	{
+		"url": "https://github.com/lando786/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/270787-thatguyorlando/",
+		"name": "ThatGuyOrlando's Repository",
+		"duplicated": {
+			"triliumnext/notes:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/kclif9/Unraid_Templates",
+		"profile": "https://forums.unraid.net/profile/279194-bluelamp3445/",
+		"name": "blue.lamp3445's Repository"
+	},
+	{
+		"url": "https://github.com/waazaa-fr/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/132702-waazaa/",
+		"name": "waazaa's Repository"
+	},
+	{
+		"url": "https://github.com/bpivk/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/67984-gxs/",
+		"name": "gxs' Repository"
+	},
+	{
+		"url": "https://github.com/l4rm4nd/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/279319-lrvt/",
+		"name": "LVRT's Repository"
+	},
+	{
+		"url": "https://github.com/dgongut/UnRAID-Templates",
+		"profile": "https://forums.unraid.net/profile/250140-dgongut/",
+		"name": "dgongut's Repository"
+	},
+	{
+		"url": "https://github.com/R3yn4ld/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/77730-reynald/",
+		"name": "Reynald's Repository"
+	},
+	{
+		"url": "https://github.com/donkevlar/Unraid-Docker-Templates",
+		"profile": "https://forums.unraid.net/profile/86041-donkevlar/",
+		"name": "DonKevlar's Repository"
+	},
+	{
+		"url": "https://github.com/mandarons/icloud-drive-docker",
+		"profile": "https://forums.unraid.net/profile/278021-mandarons/",
+		"name": "mandarons' Repository"
+	},
+	{
+		"url": "https://github.com/WaffleMaster22/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/278326-waffle22/",
+		"name": "Waffle22's Repository"
+	},
+	{
+		"url": "https://github.com/Peuuuur-Noel/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/155305-peuuuur-noel/",
+		"name": "Peuuuur Noel's Repository"
+	},
+	{
+		"url": "https://github.com/J000K3R/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/127281-j000k3r/",
+		"name": "J000K3R's Repository"
+	},
+	{
+		"url": "https://github.com/bfox135/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/174793-bfox135/",
+		"name": "Bfox135's Repository"
+	},
+	{
+		"url": "https://github.com/Garethp/rolemaster-era-server-unraid",
+		"profile": "https://forums.unraid.net/profile/243895-garethp/",
+		"name": "Garethp's Repository"
+	},
+	{
+		"url": "https://github.com/czerus/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/277784-sajnti/",
+		"name": "sajnti's Repository"
+	},
+	{
+		"url": "https://github.com/JamsRepos/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
+		"name": "LubricantJam's Repository",
+		"duplicated": {
+			"ghcr.io/schaka/janitorr:native-stable": true
+		}
+	},
+	{
+		"url": "https://github.com/manyfold3d/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/277882-floppyuk/",
+		"name": "FloppyUK's Repository"
+	},
+	{
+		"url": "https://github.com/Entree3k/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/201585-entree3000/",
+		"name": "entree3000's Repository"
+	},
+	{
+		"url": "https://github.com/wizarrrr/wizarr",
+		"profile": "https://forums.unraid.net/profile/271866-lubricantjam/",
+		"name": "Official Wizarr Repository"
+	},
+	{
+		"url": "https://github.com/Unknowncall/adsb-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/206238-unknowncall/",
+		"name": "Unknowncall's Repository"
+	},
+	{
+		"url": "https://github.com/J000K3R/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/127281-j000k3r/",
+		"name": "J000K3R's Repository"
+	},
+	{
+		"url": "https://github.com/JW-CH/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/268715-janmer/",
+		"name": "janmer's Repository"
+	},
+	{
+		"url": "https://github.com/petersem/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/240191-petersem/",
+		"name": "petersem's Repository"
+	},
+	{
+		"url": "https://github.com/Collectathon/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/209526-collectathon/",
+		"name": "Collectathon's Repository"
+	},
+	{
+		"url": "https://github.com/RichKidsDev/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/156616-grafgenixs/",
+		"name": "GrafGenixs' Repository"
+	},
+	{
+		"url": "https://github.com/catalinberta/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/258399-dracon/",
+		"name": "dracon's Repository"
+	},
+	{
+		"url": "https://github.com/type0dev/Unraid-Template",
+		"profile": "https://forums.unraid.net/profile/275726-type0dev/",
+		"name": "type0dev's Repository"
+	},
+	{
+		"url": "https://github.com/Richy1989/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/125824-richy1989/",
+		"name": "Richy1989's Repository"
+	},
+	{
+		"url": "https://github.com/iamlite/UnraidCA-GuppyFLO",
+		"profile": "https://forums.unraid.net/profile/275562-lite/",
+		"name": "Lite's Repository"
+	},
+	{
+		"url": "https://github.com/sbondCo/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/274118-unwieldy_dingy/",
+		"name": "unwieldy_dingy's Repository"
+	},
+	{
+		"url": "https://github.com/Drazzilb08/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/63966-drazzilb/",
+		"name": "Drazzilb's Repository"
+	},
+	{
+		"url": "https://github.com/fuzzy01/unraid_plg_repo",
+		"name": "Fuzzy0101's Repository",
+		"profile": "https://forums.unraid.net/profile/143886-fuzzy0101/"
+	},
+	{
+		"name": "pducharme's Repository",
+		"url": "https://github.com/pducharme/docker-containers",
+		"forum": "http://forums.unraid.net/index.php?topic=37058",
+		"profile": "https://forums.unraid.net/profile/62479-pducharme/"
+	},
+	{
+		"name": "Balloob's Repository",
+		"url": "https://github.com/balloob/unraid-docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=36535",
+		"profile": "https://forums.unraid.net/profile/62499-balloob/"
+	},
+	{
+		"name": "Binhex's Repository",
+		"url": "https://github.com/binhex/docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=45811.0",
+		"profile": "https://forums.unraid.net/profile/11148-binhex/"
+	},
+	{
+		"name": "Spants' Repository",
+		"url": "https://github.com/spants/unraidtemplates",
+		"forum": "http://forums.unraid.net/index.php?topic=38486.0",
+		"profile": "https://forums.unraid.net/profile/2148-spants/",
+		"duplicated": {
+			"photostructure/server": true,
+			"pihole/pihole:latest": true
+		}
+	},
+	{
+		"name": "pinion's Repository",
+		"url": "https://github.com/noinip/container-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=38602.0",
+		"profile": "https://forums.unraid.net/profile/10946-pinion/"
+	},
+	{
+		"name": "Bungy's Repository",
+		"url": "https://github.com/jshridha/templates",
+		"forum": "http://forums.unraid.net/index.php?topic=38930.0",
+		"profile": "https://forums.unraid.net/profile/7061-bungy/",
+		"duplicated": {
+			"mysql": true
+		}
+	},
+	{
+		"name": "SlrG's Repository",
+		"url": "https://github.com/SlrG/docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=39050.0",
+		"profile": "https://forums.unraid.net/profile/16166-slrg/"
+	},
+	{
+		"name": "coppit's Repository",
+		"url": "https://github.com/coppit/docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=39561.0",
+		"profile": "https://forums.unraid.net/profile/167-coppit/"
+	},
+	{
+		"name": "hernandito's Repository",
+		"url": "https://github.com/hernandito/docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=39623.0",
+		"profile": "https://forums.unraid.net/profile/6274-hernandito/",
+		"duplicated": {
+			"photoprism/photoprism": true,
+			"romancin/tinymediamanager:latest": true
+		}
+	},
+	{
+		"name": "macester's Repository",
+		"url": "https://github.com/macexx/docker-templates",
+		"forum": "http://lime-technology.com/forum/index.php?topic=40630.0",
+		"profile": "https://forums.unraid.net/profile/66302-macester/"
+	},
+	{
+		"name": "Official Unraid Repository",
+		"url": "https://github.com/unraid/docker-templates",
+		"shortName": "Unraid",
+		"hideFromCA": {
+			"tailscale/tailscale:stable": true
+		}
+	},
+	{
+		"name": "linuxserver's Repository",
+		"url": "https://github.com/linuxserver/templates",
+		"forum": "http://lime-technology.com/forum/index.php?topic=42092.0"
+	},
+	{
+		"name": "sdesbure's Repository",
+		"url": "https://github.com/sdesbure/docker-containers",
+		"forum": "http://lime-technology.com/forum/index.php?topic=41543.0",
+		"profile": "https://forums.unraid.net/profile/3477-sdesbure/"
+	},
+	{
+		"name": "joch's Repository",
+		"url": "https://github.com/joch/unraid-docker-templates",
+		"forum": "http://lime-technology.com/forum/index.php?topic=43480.0",
+		"profile": "https://forums.unraid.net/profile/2607-joch/"
+	},
+	{
+		"name": "tinglis1's Repository",
+		"url": "https://github.com/tinglis1/docker-containers",
+		"forum": "http://forums.unraid.net/index.php?topic=43970.0",
+		"profile": "https://forums.unraid.net/profile/6492-tinglis1/"
+	},
+	{
+		"name": "Squid's Repository",
+		"url": "https://github.com/Squidly271/plugin-repository",
+		"profile": "https://forums.unraid.net/profile/10290-squid/",
+		"icon": "https://ipsassets.unraid.net/uploads/monthly_2020_11/1001880086_Tripping-the-Rift-Chode_400x400(1).png.2e62b6b2bd95b73615bc8b651b5615f8.png",
+		"hideFromCA": {
+			"https://raw.githubusercontent.com/Squidly271/docker.categorize/master/plugins/docker.categorize.plg": true,
+			"https://raw.githubusercontent.com/unraid/docker.categorize/master/plugins/docker.categorize.plg": true,
+			"https://raw.githubusercontent.com/unraid/community.applications/master/plugins/community.applications.plg": true,
+			"https://raw.githubusercontent.com/Squidly271/community.applications/master/plugins/community.applications.plg": true,
+			"https://raw.githubusercontent.com/unraid/fix.common.problems/master/plugins/fix.common.problems.plg": true,
+			"https://raw.githubusercontent.com/Squidly271/fix.common.problems/master/plugins/fix.common.problems.plg": true
+		}
+	},
+	{
+		"name": "coppit's Repository",
+		"url": "https://github.com/coppit/unraid-plugin-metadata",
+		"profile": "https://forums.unraid.net/profile/167-coppit/"
+	},
+	{
+		"name": "dmacias' Repository",
+		"url": "https://github.com/dmacias72/unRAID-CA",
+		"profile": "https://forums.unraid.net/profile/11874-dmacias/"
+	},
+	{
+		"name": "steini84's Repository",
+		"url": "https://github.com/Steini1984/steini1984-s-repositoy",
+		"profile": "https://forums.unraid.net/profile/2957-steini84/"
+	},
+	{
+		"name": "SlrG's Repository",
+		"url": "https://github.com/SlrG/unRAID",
+		"profile": "https://forums.unraid.net/profile/16166-slrg/"
+	},
+	{
+		"name": "Emby Repository",
+		"url": "https://github.com/MediaBrowser/Emby.Build",
+		"forum": "https://lime-technology.com/forum/index.php?topic=45444.0"
+	},
+	{
+		"name": "dibbz' Repository",
+		"url": "https://github.com/quimnut/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/15731-dibbz/",
+		"duplicated": {
+			"tabbyml/tabby": true
+		}
+	},
+	{
+		"name": "ken-ji's Repository",
+		"url": "https://github.com/roninkenji/unraid-docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=46401.0",
+		"profile": "https://forums.unraid.net/profile/62359-ken-ji/"
+	},
+	{
+		"name": "docgyver's Repository",
+		"url": "https://github.com/docgyver/unraid-v6-plugins",
+		"profile": "https://forums.unraid.net/profile/21303-docgyver/"
+	},
+	{
+		"name": "bashNinja's Repository",
+		"url": "https://github.com/miketweaver/docker-templates",
+		"profile": "https://forums.unraid.net/profile/69309-bashninja/"
+	},
+	{
+		"name": "ninthwalker's Repository",
+		"url": "https://github.com/ninthwalker/docker-templates",
+		"profile": "https://forums.unraid.net/profile/9420-ninthwalker/"
+	},
+	{
+		"name": "Paul_Ber's Repository",
+		"url": "https://github.com/paulpoco/docker-templates",
+		"profile": "https://forums.unraid.net/profile/69794-paul_ber/",
+		"deprecated": {
+			"wiserain/flexget:latest": true
+		}
+	},
+	{
+		"name": "stuckless' Repository",
+		"url": "https://github.com/stuckless/unRAID",
+		"profile": "https://forums.unraid.net/profile/70058-stuckless/",
+		"duplicated": {
+			"crazifuzzy/opendct": true
+		}
+	},
+	{
+		"name": "thomast_88's Repository",
+		"url": "https://github.com/tynor88/docker-templates",
+		"profile": "https://forums.unraid.net/profile/70206-thomast_88/"
+	},
+	{
+		"name": "Bjonness406's Repository",
+		"url": "https://github.com/bjonness406/Docker-templates",
+		"profile": "https://forums.unraid.net/profile/68356-bjonness406/"
+	},
+	{
+		"name": "Huxy's Repository",
+		"url": "https://github.com/HuxyUK/docker-containers",
+		"profile": "https://forums.unraid.net/profile/70544-huxy/"
+	},
+	{
+		"name": "Roland's Repository",
+		"url": "https://github.com/Data-Monkey/docker-templates",
+		"profile": "https://forums.unraid.net/profile/62021-roland/",
+		"duplicated": {
+			"meisnate12/plex-meta-manager": true
+		}
+	},
+	{
+		"name": "jcreynolds' Repository",
+		"url": "https://github.com/jcreynolds/docker-templates",
+		"profile": "https://forums.unraid.net/profile/65204-jcreynoldsii/"
+	},
+	{
+		"name": "JugniJi's Repository",
+		"url": "https://github.com/shaf/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/71085-jugniji/"
+	},
+	{
+		"name": "atribe's Repository",
+		"url": "https://github.com/atribe/unRAID-docker",
+		"forum": "https://lime-technology.com/forum/index.php?topic=51498.0",
+		"profile": "https://forums.unraid.net/profile/70671-atribe/",
+		"duplicated": {
+			"hexparrot/mineos:latest": true,
+			"nicolargo/glances": true
+		}
+	},
+	{
+		"name": "Kru-X's Repository",
+		"url": "https://github.com/Kru-x/unraid-docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=52687.0",
+		"profile": "https://forums.unraid.net/profile/69435-kru-x/",
+		"duplicated": {
+			"mongo": true
+		}
+	},
+	{
+		"name": "jbrodriguez's Repository",
+		"url": "https://github.com/jbrodriguez/unraid",
+		"profile": "https://forums.unraid.net/profile/593-jbrodriguez/"
+	},
+	{
+		"name": "Waseh's Repository",
+		"url": "https://github.com/Waseh/unraidtemplates",
+		"profile": "https://forums.unraid.net/profile/5193-waseh/"
+	},
+	{
+		"name": "Uirel's Repository",
+		"url": "https://github.com/Poag/docker-xml",
+		"profile": "https://forums.unraid.net/profile/63933-uirel/"
+	},
+	{
+		"name": "Thraxis' Repository",
+		"url": "https://github.com/Thraxis/docker-templates",
+		"profile": "https://forums.unraid.net/profile/9802-thraxis/"
+	},
+	{
+		"name": "cheesemarathon's Repository",
+		"url": "https://github.com/BB-BenBridges/docker-templates",
+		"profile": "https://forums.unraid.net/profile/70291-cheesemarathon/",
+		"duplicated": {
+			"metabase/metabase": true
+		}
+	},
+	{
+		"name": "Taddeusz' Repository",
+		"url": "https://github.com/jason-bean/docker-templates",
+		"profile": "https://forums.unraid.net/profile/71020-taddeusz/",
+		"duplicated": {
+			"mcr.microsoft.com/mssql/server:2019-latest": true
+		}
+	},
+	{
+		"name": "Official Plex Repository",
+		"url": "https://github.com/plexinc/pms-docker",
+		"recommended": true,
+		"shortName": "Plex"
+	},
+	{
+		"name": "clowrym's Repository",
+		"url": "https://github.com/clowrym/docker-templates",
+		"profile": "https://forums.unraid.net/profile/26570-clowrym/"
+	},
+	{
+		"url": "https://github.com/brettm357/docker-templates",
+		"name": "brettm357's Repository",
+		"profile": "https://forums.unraid.net/profile/62222-brettm357/"
+	},
+	{
+		"url": "https://github.com/jlesage/docker-templates",
+		"name": "Djoss' Repository",
+		"profile": "https://forums.unraid.net/profile/73771-djoss/"
+	},
+	{
+		"url": "https://github.com/dlandon/docker.templates",
+		"name": "dlandon's Repository",
+		"profile": "https://forums.unraid.net/profile/6013-dlandon/",
+		"hideFromCA": {
+			"https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices.plg": true,
+			"https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices.plg": true,
+			"https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices.preclear.plg": true,
+			"https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices.preclear.plg": true,
+			"https://raw.githubusercontent.com/dlandon/unassigned.devices/master/unassigned.devices-plus.plg": true,
+			"https://raw.githubusercontent.com/unraid/unassigned.devices/master/unassigned.devices-plus.plg": true,
+			"https://raw.githubusercontent.com/dlandon/tips.and.tweaks/master/tips.and.tweaks.plg": true,
+			"https://raw.githubusercontent.com/unraid/tips.and.tweaks/master/tips.and.tweaks.plg": true,
+			"https://raw.githubusercontent.com/dlandon/cache_dirs/master/dlandon.cache.dirs.plg": true,
+			"https://raw.githubusercontent.com/unraid/cache_dirs/master/dlandon.cache.dirs.plg": true,
+			"https://raw.githubusercontent.com/dlandon/recycle.bin/master/recycle.bin.plg": true,
+			"https://raw.githubusercontent.com/unraid/recycle.bin/master/recycle.bin.plg": true
+		}
+	},
+	{
+		"url": "https://github.com/JustinAiken/unraid-docker-templates",
+		"name": "JustinAiken's Repository",
+		"profile": "https://forums.unraid.net/profile/1079-justinaiken/"
+	},
+	{
+		"url": "https://github.com/deasmi/unraid-ca",
+		"name": "dsmith44's Repository",
+		"profile": "https://forums.unraid.net/profile/73313-dsmith44/"
+	},
+	{
+		"url": "https://github.com/fanningert/unraid-docker-templates",
+		"name": "fanningert's Repository",
+		"profile": "https://forums.unraid.net/profile/77170-fanningert/",
+		"duplicated": {
+			"coderaiser/cloudcmd:latest-alpine": true
+		}
+	},
+	{
+		"url": "https://github.com/Malfurious/docker-templates",
+		"name": "malfurious' Repository",
+		"profile": "https://forums.unraid.net/profile/77149-malfurious/"
+	},
+	{
+		"url": "https://github.com/malvarez00/unRAID-Docker-Templates",
+		"name": "malvarez00's Repository",
+		"profile": "https://forums.unraid.net/profile/77549-malvarez00/",
+		"duplicated": {
+			"gitlab/gitlab-ce": true
+		}
+	},
+	{
+		"url": "https://github.com/rroller/unraid-templates",
+		"name": "runraid's Repository",
+		"profile": "https://forums.unraid.net/profile/75343-runraid/",
+		"duplicated": {
+			"deepquestai/deepstack": true,
+			"hotio/prowlarr:nightly": true
+		}
+	},
+	{
+		"url": "https://github.com/MarkusMcNugen/docker-templates",
+		"name": "MarkusMcNugen's Repository",
+		"profile": "https://forums.unraid.net/profile/79684-markusmcnugen/",
+		"duplicated": {
+			"technosoft2000/calibre-web": true
+		}
+	},
+	{
+		"url": "https://github.com/juusujanar/unraid-templates",
+		"name": "jj9987's Repository",
+		"profile": "https://forums.unraid.net/profile/79768-jj9987/",
+		"duplicated": {
+			"registry.hub.docker.com/portainer/portainer-ce": true
+		}
+	},
+	{
+		"url": "https://github.com/Jcloud67/Docker-Templates",
+		"name": "JCloud's Repository",
+		"profile": "https://forums.unraid.net/profile/67922-jcloud/",
+		"forum": "https://lime-technology.com/forums/topic/69422-support-qdirstat-and-storj/"
+	},
+	{
+		"url": "https://github.com/tombowditch/docker-templates",
+		"name": "tombowditch's Repository",
+		"profile": "https://forums.unraid.net/profile/80184-tombowditch/"
+	},
+	{
+		"url": "https://github.com/Tautulli/Tautulli-Unraid-Template",
+		"name": "Tautulli's Repository",
+		"profile": "https://forums.unraid.net/profile/69064-wreave/",
+		"recommended": true
+	},
+	{
+		"url": "https://github.com/jbartlett777/DiskSpeed",
+		"name": "JBartlett's Repository",
+		"profile": "https://forums.unraid.net/profile/8307-jbartlett/"
+	},
+	{
+		"url": "https://github.com/zyphermonkey/docker-templates",
+		"name": "zyphermonkey's Repository",
+		"profile": "https://forums.unraid.net/profile/67871-zyphermonkey/"
+	},
+	{
+		"url": "https://github.com/Mudislander/docker-templates",
+		"name": "Mudislander's Repository",
+		"profile": "https://forums.unraid.net/profile/67039-mudislander/"
+	},
+	{
+		"url": "https://github.com/Spikhalskiy/docker-templates",
+		"name": "Spikhalskiy's Repository",
+		"profile": "https://forums.unraid.net/profile/82549-dmitry-spikhalskiy/"
+	},
+	{
+		"url": "https://github.com/digiblur/unraid-docker-templates",
+		"name": "digiblur's Repository",
+		"profile": "https://forums.unraid.net/profile/75995-digiblur/",
+		"forum": "https://lime-technology.com/forums/topic/72033-support-digiblurs-docker-template-repository/",
+		"duplicated": {
+			"deepquestai/deepstack": true,
+			"nico640/docker-unms": true
+		}
+	},
+	{
+		"url": "https://github.com/CorneliousJD/Docker-Templates",
+		"name": "CorneliousJD's Repository",
+		"profile": "https://forums.unraid.net/profile/78194-corneliousjd/",
+		"duplicated": {
+			"ghcr.io/imagegenius/immich:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/mlebjerg/docker-templates",
+		"name": "mlebjerg's Repository",
+		"profile": "https://forums.unraid.net/profile/76816-mlebjerg/"
+	},
+	{
+		"url": "https://github.com/cmccambridge/unraid-templates",
+		"name": "cmccambridge's Repository",
+		"profile": "https://forums.unraid.net/profile/83181-cmccambridge/"
+	},
+	{
+		"url": "https://github.com/itimpi/Unraid-CA-Templates",
+		"name": "itimpi's Repository",
+		"profile": "https://forums.unraid.net/profile/10897-itimpi/"
+	},
+	{
+		"url": "https://github.com/mdarkness1988/rust-server-template",
+		"name": "mdarkness1988's Repository",
+		"profile": "https://forums.unraid.net/profile/84443-mdarkness1988/"
+	},
+	{
+		"url": "https://github.com/DyonR/docker-templates",
+		"name": "Dyon's Repository",
+		"profile": "https://forums.unraid.net/profile/79298-dyon/"
+	},
+	{
+		"url": "https://github.com/dorgan/unraid-templates",
+		"name": "dorgan's Repository",
+		"profile": "https://forums.unraid.net/profile/78375-dorgan/"
+	},
+	{
+		"name": "rix's Repository",
+		"url": "https://github.com/rix1337/docker-templates",
+		"forum": "http://forums.unraid.net/index.php?topic=43669.0",
+		"profile": "https://forums.unraid.net/profile/67339-rix/"
+	},
+	{
+		"name": "shrmn's Repository",
+		"url": "https://github.com/shrmnk/docker-templates",
+		"profile": "https://forums.unraid.net/profile/77786-shrmn/"
+	},
+	{
+		"url": "https://github.com/SiwatINC/unraid-ca-repository",
+		"name": "Siwat2545's Repository",
+		"profile": "https://forums.unraid.net/profile/72489-siwat2545/",
+		"duplicated": {
+			"zwavejs/zwavejs2mqtt": true,
+			"machinebox/facebox": true
+		}
+	},
+	{
+		"url": "https://github.com/benderstwin/docker-templates",
+		"name": "Bender's Repository",
+		"profile": "https://forums.unraid.net/profile/11326-bryanwirth/",
+		"duplicated": {
+			"acockburn/appdaemon": true,
+			"traefik:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/dersimn/docker-unraid-templates",
+		"name": "seim's Repository",
+		"profile": "https://forums.unraid.net/profile/11673-seim/",
+		"duplicated": {
+			"seafileltd/seafile": true
+		}
+	},
+	{
+		"url": "https://github.com/fithwum/files-for-dockers",
+		"name": "fithwum's Repository",
+		"profile": "https://forums.unraid.net/profile/82177-fithwum/"
+	},
+	{
+		"url": "https://github.com/olehj/unraid",
+		"name": "FlamongOle's Repository",
+		"profile": "hhttps://forums.unraid.net/profile/86216-flamongole/"
+	},
+	{
+		"url": "https://github.com/GregYankovoy/docker-templates",
+		"profile": "https://forums.unraid.net/profile/88760-grack/",
+		"name": "Grack's Repository"
+	},
+	{
+		"url": "https://github.com/RazorSiM/docker-templates",
+		"name": "raz's Repository",
+		"profile": "https://forums.unraid.net/profile/84655-raz/",
+		"duplicated": {
+			"mprasil/bitwarden": true
+		}
+	},
+	{
+		"url": "https://github.com/maschhoff/docker",
+		"name": "knex666's Repository",
+		"profile": "https://forums.unraid.net/profile/71048-knex666/",
+		"duplicated": {
+			"adolfintel/speedtest": true,
+			"openproject/community:13": true,
+			"filebrowser/filebrowser": true
+		}
+	},
+	{
+		"url": "https://github.com/MobiusNine/docker-templates",
+		"name": "MobiusNine's Repository",
+		"profile": "https://forums.unraid.net/profile/84666-mobiusnine/"
+	},
+	{
+		"url": "https://github.com/Ulisses1478/templates-unraid",
+		"name": "ulisses1478's Repository",
+		"profile": "https://forums.unraid.net/profile/90485-ulisses1478/"
+	},
+	{
+		"url": "https://github.com/FoxxMD/unraid-docker-templates",
+		"name": "FoxxMD's Repository",
+		"profile": "https://forums.unraid.net/profile/85599-foxxmd/"
+	},
+	{
+		"url": "https://github.com/ich777/docker-templates",
+		"name": "ich777's Repository",
+		"profile": "https://forums.unraid.net/profile/72388-ich777/",
+		"duplicated": {
+			"photoprism/photoprism": true
+		},
+		"hideFromCA": {
+			"https://raw.githubusercontent.com/ich777/unraid-nvidia-driver/master/nvidia-driver.plg": true,
+			"https://raw.githubusercontent.com/unraid/unraid-nvidia-driver/master/nvidia-driver.plg": true,
+			"https://raw.githubusercontent.com/ich777/unraid-dvb-driver/master/dvb-driver.plg": true,
+			"https://raw.githubusercontent.com/unraid/unraid-dvb-driver/master/dvb-driver.plg": true,
+			"https://raw.githubusercontent.com/ich777/unraid-coral-driver/master/coral-driver.plg": true,
+			"https://raw.githubusercontent.com/unraid/unraid-coral-driver/master/coral-driver.plg": true
+		}
+	},
+	{
+		"url": "https://github.com/simse/docker-templates",
+		"name": "simse's Repository",
+		"profile": "https://forums.unraid.net/profile/69400-simse/"
+	},
+	{
+		"url": "https://github.com/Josh5/unraid-docker-templates",
+		"name": "Josh.5's Repository",
+		"profile": "https://forums.unraid.net/profile/76627-josh5/"
+	},
+	{
+		"url": "https://github.com/angelics/unraid-docker-template",
+		"name": "josywong's Repository",
+		"profile": "https://forums.unraid.net/profile/7122-josywong/"
+	},
+	{
+		"url": "https://github.com/kubedzero/unraid-community-apps-xml",
+		"name": "kubed_zero's Repository",
+		"profile": "https://forums.unraid.net/profile/12026-kubed_zero/"
+	},
+	{
+		"url": "https://github.com/ijabz/songkong_unraid/",
+		"name": "Official Songkong Repository",
+		"recommended": true,
+		"shortName": "Songkong"
+	},
+	{
+		"url": "https://github.com/tquizzle/Docker-xml",
+		"name": "TQ's Repository",
+		"profile": "https://forums.unraid.net/profile/13228-tq/",
+		"duplicated": {
+			"pufferpanel/pufferpanel": true,
+			"itzg/minecraft-server:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/andrew207/splunk",
+		"name": "Andrew207's Repository",
+		"profile": "https://forums.unraid.net/profile/77842-andrew207/"
+	},
+	{
+		"url": "https://github.com/jbreed/docker-templates",
+		"name": "jbreed's Repository",
+		"profile": "https://forums.unraid.net/profile/92695-jbreed/"
+	},
+	{
+		"url": "https://github.com/selfhosters/unRAID-CA-templates",
+		"name": "Selfhosters Unraid Discord Repository",
+		"shortName": "Selfhosters",
+		"duplicated": {
+			"josh5/unmanic": true,
+			"hotio/plex": true,
+			"hotio/cloudflare-ddns": true,
+			"hotio/hddtemp2influxdb": true,
+			"koenkk/zigbee2mqtt": true,
+			"nwithan8/tauticord:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/alturismo/unraid_templates",
+		"name": "alturismo's Repository",
+		"profile": "https://forums.unraid.net/profile/70845-alturismo/"
+	},
+	{
+		"url": "https://github.com/StevenDTX/unraid-plugin-repository",
+		"name": "StevenD's Repository",
+		"profile": "https://forums.unraid.net/profile/778-stevend/"
+	},
+	{
+		"url": "https://github.com/kiwimato/unraid-templates",
+		"name": "Mihai's Repository",
+		"profile": "https://forums.unraid.net/profile/89549-mihai/"
+	},
+	{
+		"url": "https://github.com/xthursdayx/docker-templates",
+		"profile": "https://forums.unraid.net/profile/69067-zandrsn/",
+		"name": "xthursdayx's Repository",
+		"duplicated": {
+			"benbusby/whoogle-search": true,
+			"nzbgetcom/nzbget:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/d8sychain/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/72950-d8sychain/",
+		"name": "d8sychain's Repository"
+	},
+	{
+		"url": "https://github.com/Dimtar/unraidtemplates",
+		"profile": "https://forums.unraid.net/profile/7694-dimtar/",
+		"name": "dimtar's Repository"
+	},
+	{
+		"url": "https://github.com/SpaceinvaderOne/Docker-Templates-Unraid",
+		"profile": "https://forums.unraid.net/profile/67288-spaceinvaderone/",
+		"name": "SpaceInvaderOne's Repository"
+	},
+	{
+		"url": "https://github.com/d8ahazard/unraid-repository",
+		"name": "d8ahazard's Repository"
+	},
+	{
+		"url": "https://github.com/Knoxie/UnraidTemplates",
+		"name": "Knoxie89's Repository",
+		"profile": "https://forums.unraid.net/profile/78069-knoxie89/"
+	},
+	{
+		"url": "https://github.com/DavidSpek/unraid_docker_templates",
+		"name": "DavidSpek's Repository",
+		"profile": "https://forums.unraid.net/profile/96461-davidspek"
+	},
+	{
+		"url": "https://github.com/AMJidovu/unraid-repository",
+		"name": "Jidovu Marius Adrian's Repository",
+		"profile": "https://forums.unraid.net/profile/86478-jidovu-marius-adrian/"
+	},
+	{
+		"url": "https://github.com/wbynum/docker-templates",
+		"name": "Aggie1999's Repository",
+		"profile": "https://forums.unraid.net/profile/97630-aggie1999/"
+	},
+	{
+		"url": "https://github.com/frakman1/docker-templates",
+		"name": "frakman1's Repository",
+		"profile": "https://forums.unraid.net/profile/96005-frakman1",
+		"duplicated": {
+			"gitlab/gitlab-ce": true,
+			"tynor88/rclone-mount:dev": true,
+			"tynor88/rclone:dev": true,
+			"tynor88/socat": true,
+			"tynor88/unoeuro-dns": true
+		}
+	},
+	{
+		"url": "https://github.com/ElectricBrainUK/docker-templates",
+		"name": "ElectricBrainUK's Repository",
+		"profile": "https://forums.unraid.net/profile/98185-electricbrainuk"
+	},
+	{
+		"url": "https://github.com/JTok/unraid-plugins",
+		"name": "JTok's Repository",
+		"profile": " https://forums.unraid.net/profile/75269-jtok/"
+	},
+	{
+		"url": "https://github.com/hotio/unraid-templates",
+		"name": "hotio's Repository",
+		"profile": "https://forums.unraid.net/profile/94356-hotio"
+	},
+	{
+		"url": "https://github.com/CyanLabs/unraid-plugins",
+		"name": "Fma965's Repository",
+		"profile": "https://forums.unraid.net/profile/72406-fma965/"
+	},
+	{
+		"url": "https://github.com/Skitals/unraid-ca-templates",
+		"name": "Skitals Repository",
+		"profile": "https://forums.unraid.net/profile/97624-skitals/"
+	},
+	{
+		"url": "https://github.com/ljm42/unraid-templates",
+		"name": "ljm42's Repository",
+		"profile": "https://forums.unraid.net/profile/61877-ljm42/"
+	},
+	{
+		"url": "https://github.com/dcflachs/plugin-repository",
+		"name": "primeval_god's Repository",
+		"profile": "https://forums.unraid.net/profile/63584-primeval_god/"
+	},
+	{
+		"url": "https://github.com/CyaOnDaNet/unraid-templates",
+		"name": "CyaOnDaNet's Repository",
+		"profile": "https://forums.unraid.net/profile/100638-cyaondanet/"
+	},
+	{
+		"url": "https://github.com/A75G/docker-templates",
+		"name": "A75G's Repository",
+		"profile": "https://forums.unraid.net/profile/92683-a75g/",
+		"duplicated": {
+			"vabene1111/recipes:latest": true,
+			"ccarney16/pterodactyl-panel:latest": true,
+			"registry.gitlab.com/timvisee/send:latest": true,
+			"ghcr.io/seriousm4x/upsnap:4": true,
+			"archivebox/archivebox:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/dalekseevs/Unraid-Docker-Templates",
+		"name": "MrChunky's Repository",
+		"profile": "https://forums.unraid.net/profile/74482-mrchunky"
+	},
+	{
+		"url": "https://github.com/RandomNinjaAtk/unraid-templates",
+		"name": "randomninjaatk's Repository",
+		"profile": "https://forums.unraid.net/profile/9890-randomninjaatk/"
+	},
+	{
+		"url": "https://github.com/b3rs3rk/gpustat-unraid",
+		"name": "b3rs3rk's Repository",
+		"profile": "https://forums.unraid.net/profile/103683-b3rs3rk"
+	},
+	{
+		"url": "https://github.com/GuildDarts/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/80260-guilddarts/",
+		"name": "GuildDart's Repository"
+	},
+	{
+		"url": "https://github.com/DavidSpek/homelablabelmaker",
+		"profile": "https://forums.unraid.net/profile/96461-davidspek/",
+		"name": "DavidSpek's Repository"
+	},
+	{
+		"url": "https://github.com/D34DC3N73R/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/101684-d34dc3n73r/",
+		"name": "D34DC3N73R's Repository"
+	},
+	{
+		"url": "https://github.com/kiowadriver/unraid-docker",
+		"profile": "https://forums.unraid.net/profile/74645-kiowa2005/",
+		"name": "kiowa2005's Repository"
+	},
+	{
+		"url": "https://github.com/mikeylikesrocks/unraid-docker-templates",
+		"name": "mikeylikesrocks' Repository",
+		"profile": "https://forums.unraid.net/profile/89382-mikeylikesrocks"
+	},
+	{
+		"url": "https://github.com/P3R-CO/unraid",
+		"name": "capt.asic's Repository",
+		"profile": "https://forums.unraid.net/profile/106374-captasic/"
+	},
+	{
+		"url": "https://github.com/bluegizmo83/DockerXMLs",
+		"name": "bluegizmo83's Repository",
+		"profile": "https://forums.unraid.net/profile/105585-bluegizmo83"
+	},
+	{
+		"url": "https://github.com/Womabre/unraid-docker-templates",
+		"name": "Womabre's Repository",
+		"profile": "https://forums.unraid.net/profile/90075-womabre"
+	},
+	{
+		"url": "https://github.com/SAL-e/docker-templates",
+		"name": "SAL-e's Repository",
+		"profile": "https://forums.unraid.net/profile/11345-sal-e/"
+	},
+	{
+		"url": "https://github.com/GlassedSilver/unRAID-CAs",
+		"name": "Glassed Silver's Repository",
+		"profile": "https://forums.unraid.net/profile/91241-glassed-silver"
+	},
+	{
+		"url": "https://github.com/brianmiller/docker-templates",
+		"name": "TheBrian's Repository",
+		"profile": "https://forums.unraid.net/profile/86892-thebrian"
+	},
+	{
+		"url": "https://github.com/NotExpectedYet/OctoFarm-UnRaid-Template",
+		"name": "mearman's Repository",
+		"profile": "https://forums.unraid.net/profile/100446-mearman"
+	},
+	{
+		"url": "https://github.com/OctoPrint/Unraid-Template",
+		"name": "mearman's 2nd Repository",
+		"profile": "https://forums.unraid.net/profile/100446-mearman",
+		"duplicated": {
+			"octoprint/octoprint:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/ibracorp/unraid-templates",
+		"name": "IBRACORP's Repository",
+		"profile": "https://forums.unraid.net/profile/106623-sycotix/",
+		"duplicated": {
+			"linuxserver/babybuddy": true,
+			"jorenn92/maintainerr:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/natcoso9955/unRAID-docker",
+		"name": "Natcoso9955's Repository",
+		"profile": "https://forums.unraid.net/profile/73128-natcoso9955/"
+	},
+	{
+		"url": "https://github.com/opal06/unraid_docker_templates",
+		"name": "opal_06's Repository",
+		"profile": "https://forums.unraid.net/profile/110756-opal_06/"
+	},
+	{
+		"url": "https://github.com/BGameiro2000/unraid-ca",
+		"profile": "https://forums.unraid.net/profile/110702-bgameiro/",
+		"name": "BGameiro's Repository"
+	},
+	{
+		"url": "https://github.com/openspeedtest/unraid-docker-plugin",
+		"profile": "https://forums.unraid.net/profile/110999-openspeedtest/",
+		"name": "openspeedtest's Repository"
+	},
+	{
+		"url": "https://github.com/charlescng/docker-containers",
+		"name": "uberchuckie's Repository",
+		"profile": "https://forums.unraid.net/profile/64811-uberchuckie/"
+	},
+	{
+		"url": "https://github.com/Organizr/docker-organizr",
+		"name": "Organizr Repository"
+	},
+	{
+		"url": "https://github.com/rantanlan/unraid-templates",
+		"name": "mason's Repository",
+		"profile": "https://forums.unraid.net/profile/914-mason"
+	},
+	{
+		"url": "https://github.com/BoKKeR/RSSTT-Unraid",
+		"name": "BoKKeR's Repository",
+		"profile": "https://forums.unraid.net/profile/94594-bokker"
+	},
+	{
+		"url": "https://github.com/chacawaca/post-recording-xml",
+		"name": "Chacawaca's Repository",
+		"profile": "https://forums.unraid.net/profile/111526-chacawaca"
+	},
+	{
+		"url": "https://github.com/testdasi/testdasi-unraid-repo",
+		"name": "testdasi's Repository",
+		"profile": "https://forums.unraid.net/profile/70144-testdasi"
+	},
+	{
+		"url": "https://github.com/Progeny42/unRAID-CA-Templates",
+		"name": "Progeny42's Repository",
+		"profile": "https://forums.unraid.net/profile/101997-progeny42"
+	},
+	{
+		"url": "https://github.com/roflcoopter/viseron-unraid-ca-template",
+		"name": "roflcoopter's Repository",
+		"profile": "https://forums.unraid.net/profile/113120-roflcoopter"
+	},
+	{
+		"url": "https://github.com/agusalex/docker-templates",
+		"name": "agusalex' Repository",
+		"profile": "https://forums.unraid.net/profile/80800-agusalex"
+	},
+	{
+		"url": "https://github.com/doron1/unraid-plugins",
+		"name": "doron's Repository",
+		"profile": "https://forums.unraid.net/profile/8006-doron/"
+	},
+	{
+		"url": "https://github.com/tmchow/unraid-docker-templates",
+		"name": "tmchow's Repository",
+		"profile": "https://forums.unraid.net/profile/69431-tmchow/"
+	},
+	{
+		"url": "https://github.com/argash/amongusdiscord_unraid",
+		"name": "argash's Repository",
+		"profile": "https://forums.unraid.net/profile/112259-argash/"
+	},
+	{
+		"url": "https://gitlab.com/yayitazale/unraid-templates",
+		"name": "yayitazale's Repository",
+		"profile": "https://forums.unraid.net/profile/88392-yayitazale/"
+	},
+	{
+		"url": "https://github.com/brycelarge/unraid-templates",
+		"name": "brycelarge's Repository",
+		"profile": "https://forums.unraid.net/profile/112270-brycelarge/"
+	},
+	{
+		"url": "https://github.com/jassycliq/Unraid-AndroidStudio-Projector",
+		"name": "jassycliq's Repository",
+		"profile": "https://forums.unraid.net/profile/116233-jassycliq/"
+	},
+	{
+		"name": "Linuxserver's Plugin Repository",
+		"url": "https://github.com/linuxserver/linuxserver-Plugin-Repository"
+	},
+	{
+		"name": "laur's Repository",
+		"url": "https://github.com/laur89/unraid-templates/",
+		"profile": "https://forums.unraid.net/profile/114193-laur/"
+	},
+	{
+		"url": "https://github.com/benhedrington/hedrington-unraid-docker-templates",
+		"name": "hedrinbc's Repository",
+		"profile": "https://github.com/benhedrington/hedrington-unraid-docker-templates"
+	},
+	{
+		"url": "https://github.com/Sdub76/unraid_docker_templates",
+		"name": "sdub's Repository",
+		"profile": "https://forums.unraid.net/profile/113369-sdub"
+	},
+	{
+		"url": "https://github.com/vinid223/unraid-docker-templates",
+		"name": "vinid223's Repository",
+		"profile": "https://forums.unraid.net/profile/91081-vinid223"
+	},
+	{
+		"url": "https://github.com/DanRegalia/UNRAID",
+		"name": "DanRegalia's Repository",
+		"profile": "https://forums.unraid.net/profile/103107-danregalia/",
+		"duplicated": {
+			"portainer/portainer-ce": true
+		}
+	},
+	{
+		"url": "https://github.com/unraid/language-templates",
+		"name": "Official Unraid Repository",
+		"shortName": "Unraid"
+	},
+	{
+		"url": "https://github.com/diamkil/docker-templates",
+		"name": "diamkil's Repository",
+		"profile": "https://forums.unraid.net/profile/114067-diamkil/"
+	},
+	{
+		"url": "https://github.com/TheAxelander/unraid_ca",
+		"name": "Axelander's Repository",
+		"profile": "https://forums.unraid.net/profile/117678-axelander/"
+	},
+	{
+		"url": "https://github.com/n8detar/docker-templates",
+		"name": "ndetar's Repository",
+		"profile": "https://forums.unraid.net/profile/104222-ndetar/"
+	},
+	{
+		"url": "https://github.com/SimonFair/unraid-plugins",
+		"name": "SimonF's Repository",
+		"profile": "https://forums.unraid.net/profile/75917-simonf"
+	},
+	{
+		"url": "https://github.com/mgutt/unraid-docker-templates",
+		"name": "mgutt's Repository",
+		"profile": "https://forums.unraid.net/profile/94359-mgutt"
+	},
+	{
+		"url": "https://github.com/wger-project/unraid-templates",
+		"name": "rge's Repository",
+		"profile": "https://forums.unraid.net/profile/118956-rge/"
+	},
+	{
+		"url": "https://github.com/ArieDed/unraid-template",
+		"name": "ArieDed's Repository",
+		"profile": "https://forums.unraid.net/profile/119153-arieded/"
+	},
+	{
+		"url": "https://github.com/Muwahhidun/unraid-docker-templates",
+		"name": "Muwahhidun's Repository",
+		"profile": "https://forums.unraid.net/profile/107652-muwahhid/",
+		"duplicated": {
+			"onlyoffice/documentserver-ee": true,
+			"nextcloud/all-in-one:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/nzzane/nzzane-unraid-repo",
+		"profile": "https://forums.unraid.net/profile/113405-flippinturt/",
+		"name": "FlippinTurt's Repository"
+	},
+	{
+		"url": "https://github.com/ganey/unraid-honeygain",
+		"name": "ganey's Repository",
+		"profile": "https://forums.unraid.net/profile/94003-ganey/",
+		"duplicated": {
+			"honeygain/honeygain": true
+		}
+	},
+	{
+		"url": "https://github.com/Flight777/unraid_justworks_templates",
+		"name": "Flight777's Repository",
+		"profile": "https://forums.unraid.net/profile/119250-flight777"
+	},
+	{
+		"url": "https://github.com/PTRFRLL/unraid-templates",
+		"name": "PTRFRLL's Repository",
+		"profile": "https://forums.unraid.net/profile/75102-ptrfrll",
+		"duplicated": {
+			"ghcr.io/meeb/tubesync:v0.9.1": true
+		}
+	},
+	{
+		"url": "https://github.com/Sabreu/unraid_templates",
+		"name": "sublivion's Repository",
+		"profile": "https://forums.unraid.net/profile/98837-sublivion/"
+	},
+	{
+		"url": "https://github.com/zgorizzo69/unraid-templates",
+		"name": "zgo's Repository",
+		"profile": "https://forums.unraid.net/profile/119851-zgo/"
+	},
+	{
+		"url": "https://github.com/bobbintb/docker-templates",
+		"name": "bobbintb's Repository",
+		"profile": "https://forums.unraid.net/profile/550-bobbintb/"
+	},
+	{
+		"url": "https://github.com/C4ArtZ/Unraid-Templates",
+		"name": "c4artz' Repository",
+		"profile": "https://forums.unraid.net/profile/106324-c4artz/"
+	},
+	{
+		"url": "https://github.com/jflo/ffsync-unraid",
+		"name": "Jflo's Repository",
+		"profile": "https://forums.unraid.net/profile/120634-jflo/"
+	},
+	{
+		"url": "https://github.com/Adidasdaniel98/RepetierDocker",
+		"name": "Codeluxe's Repository",
+		"profile": "https://forums.unraid.net/profile/120747-codeluxe/"
+	},
+	{
+		"url": "https://github.com/JmzTaylor/unraid_templates",
+		"name": "jmztaylor's Repository",
+		"profile": "https://forums.unraid.net/profile/120824-jmztaylor/"
+	},
+	{
+		"url": "https://github.com/tenasi/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/121030-johnnyp/",
+		"name": "JohnnyP's Repository"
+	},
+	{
+		"url": "https://github.com/valaypatel/unraidapps",
+		"name": "Yoda's Repository",
+		"profile": "https://forums.unraid.net/profile/120399-yoda/"
+	},
+	{
+		"url": "https://github.com/PotentialIngenuity/petio-unraid",
+		"profile": "https://forums.unraid.net/profile/107700-chargingcosmonaut/",
+		"name": "ChargingCosmonaut's Repository"
+	},
+	{
+		"url": "https://github.com/lnxd/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/114915-lnxd/",
+		"name": "lnxd's Repository"
+	},
+	{
+		"url": "https://github.com/lawryder/unraid_docker_reps",
+		"profile": "https://forums.unraid.net/profile/122425-lawryder/",
+		"name": "LawRyder's Repository"
+	},
+	{
+		"url": "https://github.com/Camc314/unraid-jellyfin-vue",
+		"name": "Camc314's Repository",
+		"profile": "https://forums.unraid.net/profile/123309-camc314/"
+	},
+	{
+		"url": "https://github.com/NixonInnes/unraid-builds-xml",
+		"profile": "https://forums.unraid.net/profile/122748-nixoninnes/",
+		"name": "NixonInnes' Repository"
+	},
+	{
+		"url": "https://github.com/cschanot/docker-templates",
+		"profile": "https://forums.unraid.net/profile/80091-cschanot/",
+		"name": "cschanot's Repository"
+	},
+	{
+		"url": "https://github.com/what-name/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/122982-jacob-bolooni/",
+		"name": "Jacob Bolooni's Repository"
+	},
+	{
+		"url": "https://github.com/EdwardChamberlain/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/122583-forum-layman/",
+		"name": "Forum-Layman's Repository"
+	},
+	{
+		"url": "https://github.com/marzel1/docker-templates",
+		"profile": "https://forums.unraid.net/profile/117249-marzel/",
+		"name": "Marzel's Repository"
+	},
+	{
+		"url": "https://github.com/jsavargas/telethon_downloader",
+		"profile": "https://forums.unraid.net/profile/93593-jsavargas/",
+		"name": "jsavargas' Repository"
+	},
+	{
+		"url": "https://github.com/PartitionPixel/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119008-partition-pixel/",
+		"name": "Partition Pixel's Repository"
+	},
+	{
+		"url": "https://github.com/guydavis/machinaris-unraid",
+		"profile": "https://forums.unraid.net/profile/126090-guydavis/",
+		"name": "guy.davis' Repository"
+	},
+	{
+		"url": "https://github.com/breadlysm/Breads-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/84220-breadlysm/",
+		"name": "breadlysm's Repository"
+	},
+	{
+		"url": "https://github.com/OFark/docker-templates",
+		"profile": "https://forums.unraid.net/profile/86513-ofark/",
+		"name": "OFark's Repository"
+	},
+	{
+		"url": "https://gitlab.com/crafty-controller/crafty-4",
+		"profile": "https://forums.unraid.net/profile/126877-freddy0/",
+		"name": "freddy0's Repository"
+	},
+	{
+		"url": "https://github.com/sgraaf/Unraid-Docker-Templates",
+		"profile": "https://forums.unraid.net/profile/119190-sgraaf/",
+		"name": "sgraaf's Repository",
+		"duplicated": {
+			"adguard/adguardhome": true
+		}
+	},
+	{
+		"url": "https://github.com/aeleos/cloudflared",
+		"profile": "https://forums.unraid.net/profile/78732-aeleos/",
+		"name": "aeleos' Repository"
+	},
+	{
+		"url": "https://github.com/pawelmalak/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119205-paululibro/",
+		"name": "paululibro's Repository"
+	},
+	{
+		"url": "https://github.com/jakemoura/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/118681-jakemoura/",
+		"name": "shaksiwnl's Repository"
+	},
+	{
+		"url": "https://github.com/Marraz/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/127460-marraz/",
+		"name": "Marraz' Repository"
+	},
+	{
+		"url": "https://github.com/daman20/ca-xmls",
+		"profile": "https://forums.unraid.net/profile/122785-daman12/",
+		"name": "daman12's Repository"
+	},
+	{
+		"url": "https://github.com/advplyr/docker-templates",
+		"profile": "https://forums.unraid.net/profile/128533-advplyr/",
+		"name": "advplyr's Repository"
+	},
+	{
+		"url": "https://github.com/vrx-666/unraid-xml",
+		"profile": "https://forums.unraid.net/profile/128590-vrx/",
+		"name": "vrx's Repository"
+	},
+	{
+		"url": "https://github.com/DiamondPrecisionComputing/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/91956-biggiesize/",
+		"name": "Diamond Precision Computing's Repository"
+	},
+	{
+		"url": "https://github.com/ptchernegovski/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/99869-ptchernegovski/",
+		"name": "ptchernegovski's Repository"
+	},
+	{
+		"url": "https://github.com/L1cardo/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/128967-licardo/",
+		"name": "licardo's Repository"
+	},
+	{
+		"url": "https://github.com/kutzilla/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/129184-kutzilla/",
+		"name": "kutzilla's Repository"
+	},
+	{
+		"url": "https://github.com/jkirkcaldy/unraid-CA-templates",
+		"profile": "https://forums.unraid.net/profile/114408-jkirkcaldy/",
+		"name": "jkirkcaldy's Repository"
+	},
+	{
+		"url": "https://github.com/Joshndroid/joshndroid-unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/123042-joshndroid/",
+		"name": "Joshndroid's Repository"
+	},
+	{
+		"url": "https://github.com/Kizaing/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/129591-kizaing/",
+		"name": "Kizaing's Repository"
+	},
+	{
+		"url": "https://github.com/lubeda/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/107977-lubeda/",
+		"name": "LuBeDa's Repository"
+	},
+	{
+		"url": "https://github.com/Frooodle/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/128782-froodle/",
+		"name": "Froodle's Repository",
+		"duplicated": {
+			"selexin/cleanarr": true
+		}
+	},
+	{
+		"url": "https://github.com/rufuswilson/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/130601-cedev/",
+		"name": "cedev's Repository"
+	},
+	{
+		"url": "https://github.com/Joey291/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/99592-cornflake/",
+		"name": "Cornflake's Repository"
+	},
+	{
+		"url": "https://github.com/llalon/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126527-llalon/",
+		"name": "llalon's Repository"
+	},
+	{
+		"url": "https://github.com/ofawx/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/109310-ofawx/",
+		"name": "ofawx's Repository"
+	},
+	{
+		"url": "https://github.com/photostructure/unraid-template",
+		"profile": "https://forums.unraid.net/profile/116201-mrm/",
+		"name": "Official PhotoStructure Repository",
+		"shortName": "PhotoStructure"
+	},
+	{
+		"url": "https://github.com/BigManDave/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/133103-bigmandave/",
+		"name": "BigManDave's Repository"
+	},
+	{
+		"url": "https://github.com/Olprog59/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/121454-kameleon83/",
+		"name": "Kameleon83's Repository"
+	},
+	{
+		"url": "https://github.com/ItsEcholot/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/134301-echolot/",
+		"name": "Echolot's Repository"
+	},
+	{
+		"url": "https://github.com/redvex2460/docker-templates",
+		"profile": "https://forums.unraid.net/profile/128113-redvex/",
+		"name": "RedVex's Repository"
+	},
+	{
+		"url": "https://github.com/ckocyigit/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/110566-ck98/",
+		"name": "CK98's Repository"
+	},
+	{
+		"url": "https://github.com/pairofcrocs/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/98010-crocs/",
+		"name": "Croc's Repository",
+		"duplicated": {
+			"atdr.meo.ws/archiveteam/warrior-dockerfile:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/Reaparr/Unraid-CA-Templates",
+		"profile": "https://forums.unraid.net/profile/102645-unmax/",
+		"name": "Unmax's Repository",
+		"duplicated": {
+			"plexripper/plexripper:dev": true
+		}
+	},
+	{
+		"url": "https://github.com/IkerSaint/ZFS-Master-Unraid",
+		"profile": "https://forums.unraid.net/profile/102954-iker/",
+		"name": "Iker's Repository"
+	},
+	{
+		"url": "https://github.com/m0ngr31/unraid_ca",
+		"profile": "https://forums.unraid.net/profile/75617-m0ngr31/",
+		"name": "m0ngr31's Repository",
+		"duplicated": {
+			"ghcr.io/ollama-webui/ollama-webui:main": true
+		}
+	},
+	{
+		"url": "https://github.com/corgan2222/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/102466-corgan/",
+		"name": "corgan's Repository"
+	},
+	{
+		"url": "https://github.com/glauth/unraid-glauth",
+		"profile": "https://forums.unraid.net/profile/111590-cyansmoker/",
+		"name": "cyansmoker's Repository"
+	},
+	{
+		"url": "https://github.com/lomorage/unraid-template",
+		"profile": "https://forums.unraid.net/profile/138957-dwebf/",
+		"name": "DwebF's Repository"
+	},
+	{
+		"url": "https://github.com/poke0/Unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/139781-poke0/",
+		"name": "Poke0's Repository"
+	},
+	{
+		"url": "https://github.com/patrickstigler/unraid_app_templates",
+		"profile": "https://forums.unraid.net/profile/139758-maddash1337/",
+		"name": "patrickstigler's Repository",
+		"duplicated": {
+			"mcr.microsoft.com/mssql/server:2019-latest": true,
+			"mandarons/icloud-drive": true
+		}
+	},
+	{
+		"url": "https://github.com/Goobaroo/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/113292-goobaroo/",
+		"name": "Goobaroo's Repository"
+	},
+	{
+		"url": "https://github.com/TrophyBuck/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/140258-trophybuck/",
+		"name": "TrophyBuck's Repository"
+	},
+	{
+		"url": "https://github.com/knilix/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126551-da-do-ron/",
+		"name": "da do ron's Repository"
+	},
+	{
+		"url": "https://github.com/C3004/Unraid-Templates-C3004",
+		"profile": "https://forums.unraid.net/profile/142775-c3004/",
+		"name": "C3004's Repository"
+	},
+	{
+		"url": "https://github.com/jorgenman/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/142946-jorgenman/",
+		"name": "jorgenman's Repository"
+	},
+	{
+		"url": "https://github.com/lordfiSh/unraid-docker-images",
+		"profile": "https://forums.unraid.net/profile/92815-lordfish/",
+		"name": "lordfiSh's Repository"
+	},
+	{
+		"url": "https://github.com/fileflows/FileFlowsUnraid",
+		"profile": "https://forums.unraid.net/profile/1117-reven/",
+		"name": "fileflows's Repository"
+	},
+	{
+		"url": "https://github.com/L4stIdi0t/Unraid-template",
+		"profile": "https://forums.unraid.net/profile/122421-l4stidi0t/",
+		"name": "L4stIdi0t's Repository"
+	},
+	{
+		"url": "https://github.com/StuffAnThings/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/76370-bobokun/",
+		"name": "bobokun's Repository"
+	},
+	{
+		"url": "https://github.com/locus313/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/74415-locus313/",
+		"name": "locus313's Repository"
+	},
+	{
+		"url": "https://github.com/ivaxor/unraid-ca-docker-templates",
+		"profile": "https://forums.unraid.net/profile/147445-saskiuhia/",
+		"name": "saskiuhia's Repository"
+	},
+	{
+		"url": "https://github.com/bonedrums/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/72855-bonedrums/",
+		"name": "bonedrums' Repository"
+	},
+	{
+		"url": "https://github.com/josecoelho/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/125944-jos%C3%A9-coelho/",
+		"name": "Jos\u00e9 Coelho's Repository"
+	},
+	{
+		"url": "https://github.com/Sander0542/docker-templates",
+		"profile": "https://forums.unraid.net/profile/98342-sander0542/",
+		"name": "Sander0542's Repository"
+	},
+	{
+		"url": "https://github.com/mizz141/mizz141-unraid-xml",
+		"profile": "https://forums.unraid.net/profile/98815-mizz141/",
+		"name": "Mizz141's Repository"
+	},
+	{
+		"url": "https://github.com/OpenSageTV/unRAID",
+		"profile": "https://forums.unraid.net/profile/125876-jusjoken/",
+		"name": "jusjoken's Repository"
+	},
+	{
+		"url": "https://github.com/MasterEvarior/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/140790-smithynithy/",
+		"name": "SmithyNithy's Repository"
+	},
+	{
+		"url": "https://github.com/qubex22/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/110563-joroga22/",
+		"name": "joroga22's Repository"
+	},
+	{
+		"url": "https://github.com/timstephens24/docker-templates",
+		"profile": "https://forums.unraid.net/profile/67918-timstephens24/",
+		"name": "timstephens24's Repository"
+	},
+	{
+		"url": "https://github.com/simonsickle/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/152551-ssickle/",
+		"name": "ssickle's Repository",
+		"duplicated": {
+			"influxdb": true,
+			"ghcr.io/home-assistant/home-assistant": true
+		}
+	},
+	{
+		"url": "https://github.com/oldcrazyeye/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/124305-oldcrazyeye/",
+		"name": "oldcrazyeye's Repository"
+	},
+	{
+		"url": "https://github.com/UnknownHiker/unraid-template-kitchenowl",
+		"profile": "https://forums.unraid.net/profile/155012-hansolo97/",
+		"name": "HanSolo97's Repository"
+	},
+	{
+		"url": "https://github.com/ciegg/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/155366-cieg/",
+		"name": "cieg's Repository"
+	},
+	{
+		"url": "https://github.com/FrankM77/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/153626-built2succeed/",
+		"name": "Built2Succeed's Repository"
+	},
+	{
+		"url": "https://github.com/xenco/docker-templates",
+		"profile": "https://forums.unraid.net/profile/155847-xenco/",
+		"name": "xenco's Repository"
+	},
+	{
+		"url": "https://github.com/helfrichmichael/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/68815-mikeah/",
+		"name": "MikeAH's Repository"
+	},
+	{
+		"url": "https://github.com/pierot/unraid-ca-apps",
+		"profile": "https://forums.unraid.net/profile/121203-pieterm/",
+		"name": "pieterm's Repository"
+	},
+	{
+		"url": "https://github.com/crazyqin/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/157513-mrafter/",
+		"name": "mrafter's Repository"
+	},
+	{
+		"url": "https://github.com/imTHAI/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/117577-pbear/",
+		"name": "pbear's Repository"
+	},
+	{
+		"url": "https://github.com/tipdec-siblyn/Urbit-on-Unraid",
+		"profile": "https://forums.unraid.net/profile/158043-tipdec-siblyn/",
+		"name": "tipdec-sbilyn's Repository"
+	},
+	{
+		"url": "https://github.com/MyFaith/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/157465-myfaith/",
+		"name": "MyFaith's Repository"
+	},
+	{
+		"url": "https://github.com/ep1cman/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/69221-ep1cman/",
+		"name": "ep1cman's Repository"
+	},
+	{
+		"url": "https://github.com/picthor-io/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/106558-realcnbs/",
+		"name": "realcnbs' Repository"
+	},
+	{
+		"url": "https://github.com/ItJustFox/unraidtemplate",
+		"profile": "https://forums.unraid.net/profile/142238-fantucie/",
+		"name": "Fantucie's Repository"
+	},
+	{
+		"url": "https://github.com/juchong/shapeshifter-docker-unraid",
+		"profile": "https://forums.unraid.net/profile/113997-juchong/",
+		"name": "juchong's Repository"
+	},
+	{
+		"url": "https://github.com/avpnusr/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/126700-fatzcat/",
+		"name": "FatzCat's Repository"
+	},
+	{
+		"url": "https://github.com/xavier-hernandez/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/158924-xavierh/",
+		"name": "xavierh's Repository",
+		"duplicated": {
+			"jlongster/actual-server:latest": true,
+			"xavierh/goaccess-for-nginxproxymanager": true
+		}
+	},
+	{
+		"url": "https://github.com/imthenachoman/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/134093-imthenachoman/",
+		"name": "IMTheNachoMan's Repository"
+	},
+	{
+		"url": "https://github.com/silman/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/163023-silman/",
+		"name": "silman's Repository"
+	},
+	{
+		"url": "https://github.com/JulienPlomteux/Unraid-ErgoNode",
+		"profile": "https://forums.unraid.net/profile/163009-mrlafontaine/",
+		"name": "mrlafontaine's Repository"
+	},
+	{
+		"url": "https://github.com/SavageAUS/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/91260-savageaus/",
+		"name": "SaveageAUS' Repository",
+		"duplicated": {
+			"ajnart/homarr": true
+		}
+	},
+	{
+		"url": "https://github.com/GladysAssistant/unraid-gladys-templates",
+		"profile": "https://forums.unraid.net/profile/159169-jgcb00/",
+		"name": "jgcb00's Repository"
+	},
+	{
+		"url": "https://github.com/xWeegix/templates",
+		"profile": "https://forums.unraid.net/profile/132338-xweegix/",
+		"name": "xWeegix's Repository",
+		"duplicated": {
+			"fallenbagel/jellyseerr:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/tubearchivist/unraid-templates",
+		"name": "TubeArchivist's Official Repository"
+	},
+	{
+		"url": "https://github.com/djismgaming/docker-templates",
+		"profile": "https://forums.unraid.net/profile/124577-djismgaming/",
+		"name": "djismgaming's Repository"
+	},
+	{
+		"url": "https://github.com/Darkside138/unraidtemplates",
+		"profile": "https://forums.unraid.net/profile/166210-darkside138/",
+		"name": "Darkside138's Repository"
+	},
+	{
+		"url": "https://github.com/soerentsch/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/146285-gucky79/",
+		"name": "gucky79's Repository"
+	},
+	{
+		"url": "https://github.com/maxcerny/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/93919-sysco/",
+		"name": "sysco's Repository"
+	},
+	{
+		"url": "https://github.com/JPDVM2014/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/156525-jpdvm2014/",
+		"name": "JPDVM2014's Repository",
+		"duplicated": {
+			"tomsquest/docker-radicale": true
+		}
+	},
+	{
+		"url": "https://github.com/Qlisch/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119212-kulisch/",
+		"name": "Kulisch's Repository"
+	},
+	{
+		"url": "https://github.com/sems/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/168805-sem/",
+		"name": "sem's Repository"
+	},
+	{
+		"url": "https://github.com/Th0masDB/unraid_template",
+		"profile": "https://forums.unraid.net/profile/126905-thomasdb__/",
+		"name": "ThomasDB's Repository"
+	},
+	{
+		"url": "https://github.com/NickM-27/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/128178-crzynik/",
+		"name": "crzynik's Repository"
+	},
+	{
+		"url": "https://github.com/simonjenny/unraid",
+		"profile": "https://forums.unraid.net/profile/122229-simon-jenny/",
+		"name": "Simon Jenny's Repository"
+	},
+	{
+		"url": "https://github.com/superboki/UNRAID-FR",
+		"profile": "https://forums.unraid.net/profile/92630-superboki/",
+		"name": "superboki's Repository",
+		"duplicated": {
+			"ghcr.io/taxel/plextraktsync:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/jadehawk/unRaid-Templates",
+		"profile": "https://forums.unraid.net/profile/168612-jadehawk",
+		"name": "Jadehawk's Repository"
+	},
+	{
+		"url": "https://github.com/LeonStoldt/Unraid-Community-Applications",
+		"profile": "https://forums.unraid.net/profile/170522-leonstoldt/",
+		"name": "LeonStoldt's Repository"
+	},
+	{
+		"url": "https://github.com/moritzfl/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/145080-moritzf/",
+		"name": "moritzf's Repository"
+	},
+	{
+		"url": "https://github.com/ShaneIsrael/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/168827-shane-israel/",
+		"name": "Shane Israel's Repository"
+	},
+	{
+		"url": "https://github.com/vertex-app/docker-template",
+		"profile": "https://forums.unraid.net/profile/171336-%E6%A0%97%E5%B1%B1%E6%9C%AA%E6%9D%A5/",
+		"name": "\u6817\u5c71\u672a\u6765 Repository"
+	},
+	{
+		"url": "https://github.com/mingzaily/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169573-longyunur/",
+		"name": "LongYunar's Repository"
+	},
+	{
+		"url": "https://github.com/geoffgbsn/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/144116-geoffgibby/",
+		"name": "geoff.gibby's Repository"
+	},
+	{
+		"url": "https://github.com/tritones/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/172136-tritones/",
+		"name": "tritones' Repository"
+	},
+	{
+		"url": "https://github.com/Vilhjalmr26/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/126802-vilhjalmr/",
+		"name": "Vilhjalmr's Repository"
+	},
+	{
+		"url": "https://github.com/Ratomas/CA_XML",
+		"profile": "https://forums.unraid.net/profile/85867-robert-thomas/",
+		"name": "Robert Thomas' Repository"
+	},
+	{
+		"url": "https://github.com/fiR3W4LL87/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/113873-fir3w4ll/",
+		"name": "fiR3W4LL's Repository",
+		"Deprecated": true
+	},
+	{
+		"url": "https://github.com/CollinHeist/UnraidConfig",
+		"profile": "https://forums.unraid.net/profile/172758-collinheist/",
+		"name": "CollinHeist's Repository"
+	},
+	{
+		"url": "https://github.com/Loony2392/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/152355-loony2392/",
+		"name": "Loony2392's Repository"
+	},
+	{
+		"url": "https://github.com/mikedhanson/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/88846-mikehanson/",
+		"name": "mikehanson's Repository"
+	},
+	{
+		"url": "https://github.com/kywarai/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/170658-kuuki/",
+		"name": "kuuki's Repository"
+	},
+	{
+		"url": "https://github.com/KasteM34/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169707-kastem34/",
+		"name": "kastem34's Repository",
+		"duplicated": {
+			"hashicorp/vault": true
+		}
+	},
+	{
+		"url": "https://github.com/luisalrp/unraid_docker_templates",
+		"profile": "https://forums.unraid.net/profile/115058-luisalrp/",
+		"name": "luisalrp's Repository"
+	},
+	{
+		"url": "https://github.com/Yoruio/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126098-yoruio/",
+		"name": "Yoruio's Repository"
+	},
+	{
+		"url": "https://github.com/Polemus/Unraid",
+		"profile": "https://forums.unraid.net/profile/140455-dusty-roberts/",
+		"name": "Dusty Roberts' Repository"
+	},
+	{
+		"url": "https://github.com/kilrah/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/175398-kilrah/",
+		"name": "Kilrah's Repository"
+	},
+	{
+		"url": "https://github.com/ahmadnassri/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/123283-ahmad/",
+		"name": "Ahmad's Repository"
+	},
+	{
+		"url": "https://github.com/ibigsnet/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/76488-riflejock/",
+		"name": "RifleJock's Repository"
+	},
+	{
+		"url": "https://github.com/MountainGod2/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/167420-mrslaw/",
+		"name": "mrslaw's Repository",
+		"duplicated": {
+			"corentinth/it-tools": true
+		}
+	},
+	{
+		"url": "https://github.com/Aerilym/docker-templates",
+		"profile": "https://forums.unraid.net/profile/158147-aerilym/",
+		"name": "Aerilym's Repository"
+	},
+	{
+		"url": "https://github.com/its-sven/docker-templates",
+		"profile": "https://forums.unraid.net/profile/146810-sven-w%C3%BCrth/",
+		"name": "Sven W\u00fcrth's Repository"
+	},
+	{
+		"url": "https://github.com/Srcodesalittle/cryptgeon_redis",
+		"profile": "https://forums.unraid.net/profile/131563-lamp/",
+		"name": "lamp's Repository"
+	},
+	{
+		"url": "https://github.com/thecode/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/109528-thecode/",
+		"name": "thecode's Repository"
+	},
+	{
+		"url": "https://github.com/0neTX/UnRAID_Template",
+		"profile": "https://forums.unraid.net/profile/161660-onetx/",
+		"name": "onetx's Repository"
+	},
+	{
+		"url": "https://github.com/dhruvinsh/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/146712-dhruvin/",
+		"name": "Dhruvin's Repository"
+	},
+	{
+		"url": "https://github.com/alexbn71/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169325-alexbn71/",
+		"name": "alexbn71's Repository"
+	},
+	{
+		"url": "https://github.com/kennethprose/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/174044-roseatoni/",
+		"name": "roseatoni's Repository"
+	},
+	{
+		"url": "https://github.com/twist3dimages/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/137900-exes/",
+		"name": "Exes' Repository",
+		"duplicated": {
+			"clamav/clamav": true
+		}
+	},
+	{
+		"url": "https://github.com/chrizzo84/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/135280-chrizzo/",
+		"name": "chrizzo's Repository",
+		"duplicated": {
+			"drone/drone": true,
+			"docker.io/jc21/nginx-proxy-manager": true
+		}
+	},
+	{
+		"url": "https://github.com/devzwf/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/119200-zappyzap/",
+		"name": "ZappyZap's Repository",
+		"duplicated": {
+			"lscr.io/linuxserver/speedtest-tracker:latest": true,
+			"l4rm4nd/vouchervault:1.1.x": true,
+			"l4rm4nd/vouchervault:1.4.x": true,
+			"l4rm4nd/vouchervault:1.5.x": true
+		}
+	},
+	{
+		"url": "https://github.com/ChongZhiJie0216/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/114492-chongzhijie/",
+		"name": "ChongZhiJie's Repository"
+	},
+	{
+		"url": "https://github.com/elzik/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/201488-elzik/",
+		"name": "elzik's Repository"
+	},
+	{
+		"url": "https://github.com/Mavrag/unraid-templates",
+		"name": "Mavrag's Repository",
+		"profile": "https://forums.unraid.net/profile/111982-mavrag/"
+	},
+	{
+		"url": "https://github.com/AriaGomes/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/107309-figro/",
+		"name": "Figro's Repository"
+	},
+	{
+		"url": "https://github.com/daredoes/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/157186-daredoes/",
+		"name": "daredoes' Repository"
+	},
+	{
+		"url": "https://github.com/masterwishx/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/107418-masterwishx/",
+		"name": "Masterwishx's Repository"
+	},
+	{
+		"url": "https://github.com/lewislarsen/lldap-unraid",
+		"profile": "https://forums.unraid.net/profile/143760-lewis-l/",
+		"name": "Lewis L's Repository"
+	},
+	{
+		"url": "https://github.com/piranha771/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/159409-divid/",
+		"name": "Divid's Repository",
+		"duplicated": {
+			"seafileltd/seafile-mc": true
+		}
+	},
+	{
+		"url": "https://github.com/jwillmer/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119261-jwillmer/",
+		"name": "jwillmer's Repository"
+	},
+	{
+		"url": "https://github.com/Zggis/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/118712-zggis/",
+		"name": "Zggis' Repository"
+	},
+	{
+		"url": "https://github.com/josh-gaby/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/171871-joshgaby/",
+		"name": "josh.gaby's Repository"
+	},
+	{
+		"url": "https://github.com/emptyfish/unraid-apps",
+		"profile": "https://forums.unraid.net/profile/112283-emptyfish/",
+		"name": "emptyfish's Repository"
+	},
+	{
+		"url": "https://github.com/pyrater/docker-templates",
+		"profile": "https://forums.unraid.net/profile/14118-pyrater/",
+		"name": "pyrater's Repository"
+	},
+	{
+		"url": "https://github.com/Kostecki/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/68040-kostecki/",
+		"name": "kostecki's Repository"
+	},
+	{
+		"url": "https://github.com/Balya/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/166805-balya/",
+		"name": "Balya's Repository"
+	},
+	{
+		"url": "https://github.com/ccmpbll/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/5869-ccmpbll/",
+		"name": "ccmpbll's Repository"
+	},
+	{
+		"url": "https://github.com/7oasty/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/189568-7oasty/",
+		"name": "7oasty's Repository"
+	},
+	{
+		"url": "https://github.com/Commifreak/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/140912-kluthr/",
+		"name": "KluthR's Repository"
+	},
+	{
+		"url": "https://github.com/m-klecka/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/210341-mklecka/",
+		"name": "mklecka's Repository"
+	},
+	{
+		"url": "https://github.com/PonyLucky/TendaControllerXML",
+		"profile": "https://forums.unraid.net/profile/177818-margot/",
+		"name": "Margot's Repository"
+	},
+	{
+		"url": "https://github.com/Kometa-Team/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/198915-sohjiro/",
+		"name": "Sohjiro's Repository"
+	},
+	{
+		"url": "https://github.com/dannymate/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/87501-jimrummy101/",
+		"name": "jimrummy101's Repository"
+	},
+	{
+		"url": "https://github.com/AlexGreenUK/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/116574-alexgreenuk/",
+		"name": "AlexGreenUK's Repository"
+	},
+	{
+		"url": "https://github.com/theimmortal68/zappiti-server-docker",
+		"profile": "https://forums.unraid.net/profile/67130-theimmortal/",
+		"name": "theimmortal's Repository"
+	},
+	{
+		"url": "https://github.com/manuel-rw/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/138040-manrw/",
+		"name": "manrw's Repository"
+	},
+	{
+		"url": "https://github.com/nwithan8/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/81372-grtgbln/",
+		"name": "grtgbln's Repository",
+		"duplicated": {
+			"binwiederhier/ntfy:latest": true,
+			"networkstatic/iperf3:latest": true,
+			"ghcr.io/eliasbenb/plexanibridge:latest": true,
+			"ghcr.io/maybe-finance/maybe:stable": true,
+			"ghcr.io/mediux-team/aura:latest": true,
+			"cirx08/wedding_share:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/sebtech33/unRAID-Templates",
+		"profile": "https://forums.unraid.net/profile/98806-sebtech33/",
+		"name": "SebTech33's Repository",
+		"duplicated": {
+			"crazymax/rtorrent-rutorrent": true
+		}
+	},
+	{
+		"url": "https://github.com/Belstrekkie/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/224258-bversluis/",
+		"name": "BVersluis' Repository"
+	},
+	{
+		"url": "https://github.com/imagegenius/templates",
+		"profile": "https://forums.unraid.net/profile/103573-vcxpz/",
+		"name": "imagegenius' Repository"
+	},
+	{
+		"url": "https://github.com/FreakErn/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/129382-freakern/",
+		"name": "FreakErn's Repository"
+	},
+	{
+		"url": "https://github.com/wupasscat/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/103746-wupasscat/",
+		"name": "wupasscat's Repository"
+	},
+	{
+		"url": "https://github.com/mplogas/unraid-containers",
+		"profile": "https://forums.unraid.net/profile/145679-mplogas/",
+		"name": "mplogas' Repository"
+	},
+	{
+		"url": "https://github.com/warieon/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/240351-warieon/",
+		"name": "warieon's Repository"
+	},
+	{
+		"url": "https://github.com/PepaonDrugs/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/157546-maxi_fpv/",
+		"name": "Maxi_Fpv's Repository"
+	},
+	{
+		"url": "https://github.com/Nackophilz/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/161066-nackophilz/",
+		"name": "Nackophilz's Repository"
+	},
+	{
+		"url": "https://github.com/brockbreacher/join-bot-unraid",
+		"profile": "https://forums.unraid.net/profile/171183-brockbreacher/",
+		"name": "brockbreacher's Repository"
+	},
+	{
+		"url": "https://github.com/killforby/chibisafe",
+		"profile": "https://forums.unraid.net/profile/229087-professeurx/",
+		"name": "professeurx's Repository"
+	},
+	{
+		"url": "https://github.com/npmSteven/Unraid-VM-CP",
+		"profile": "https://forums.unraid.net/profile/102900-stevenrafferty/",
+		"name": "StevenRafferty's Repository"
+	},
+	{
+		"url": "https://github.com/mastiffmushroom/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/243288-mastiffmushroom/",
+		"name": "MastiffMushroom's Repository"
+	},
+	{
+		"url": "https://github.com/mattheworres/docker-templates",
+		"profile": "https://forums.unraid.net/profile/115370-matthew-orres/",
+		"name": "Matthew Orres' Repository"
+	},
+	{
+		"url": "https://github.com/DatPat/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169502-jsrk/",
+		"name": "jsrk's Repository"
+	},
+	{
+		"url": "https://github.com/terratrax/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/230036-terratrax/",
+		"name": "terratrax's Repository"
+	},
+	{
+		"url": "https://github.com/THESHULK/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/237924-the_shulk/",
+		"name": "THE_SHULK's Repository"
+	},
+	{
+		"url": "https://github.com/kezzkezzkezz/UNRAID-Templates/",
+		"profile": "https://forums.unraid.net/profile/133849-kezzkezzkezz/",
+		"name": "kezzkezzkezz's Repository"
+	},
+	{
+		"url": "https://github.com/luigi311/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/72460-luigi311/",
+		"name": "Luigi311's Repository"
+	},
+	{
+		"url": "https://github.com/friendlyFriend4000/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/244776-friendlyfriend/",
+		"name": "FriendlyFriend's Repository"
+	},
+	{
+		"url": "https://github.com/fizzyfrys/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119591-fizzyfrys/",
+		"name": "fizzyfrys' Repository"
+	},
+	{
+		"url": "https://github.com/giganode/unraid-plugins",
+		"profile": "https://forums.unraid.net/profile/105464-giganode/",
+		"name": "giganode's Repository"
+	},
+	{
+		"url": "https://github.com/zhtengw/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/245393-zhtengw/",
+		"name": "zhtengw's Repository"
+	},
+	{
+		"url": "https://github.com/laromicas/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/172751-laromicas/",
+		"name": "laromicas' Repository"
+	},
+	{
+		"url": "https://github.com/seriousm4x/unraid-community-apps",
+		"profile": "https://forums.unraid.net/profile/246841-seriousm4x/",
+		"name": "seriousm4x's Repository"
+	},
+	{
+		"url": "https://github.com/b42n1/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/167912-b4rny/",
+		"name": "B4rny's Repository",
+		"duplicated": {
+			"frooodle/s-pdf": true
+		}
+	},
+	{
+		"url": "https://github.com/untraceablez/uvdesk-unraid",
+		"profile": "https://forums.unraid.net/profile/111430-untraceablez/",
+		"name": "untraceablez' Repository"
+	},
+	{
+		"url": "https://github.com/JACOBSMILE/Unraid_XMLS",
+		"profile": "https://forums.unraid.net/profile/141756-jacobsmile/",
+		"name": "JACOBSMILE's Repository"
+	},
+	{
+		"url": "https://github.com/JakeShirley/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/101291-darknavi/",
+		"name": "darknavi's Repository"
+	},
+	{
+		"url": "https://github.com/taha-yassine/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/248389-vodros/",
+		"name": "Vodros' Repository"
+	},
+	{
+		"url": "https://github.com/riffsphereha/Unraid-Templates",
+		"profile": "https://forums.unraid.net/profile/250924-riffsphereha/",
+		"name": "RiffSphereHA's Repository"
+	},
+	{
+		"url": "https://github.com/coreylane/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/146143-coreylane/",
+		"name": "coreylane's Repository"
+	},
+	{
+		"url": "https://github.com/snapcrescent/templates",
+		"profile": "https://forums.unraid.net/profile/226383-navalgandhi1989/",
+		"name": "snapcrescent's Repository"
+	},
+	{
+		"url": "https://github.com/mpcdigitize/docker-templates",
+		"profile": "https://forums.unraid.net/profile/249625-petel/",
+		"name": "PeteL's Repository"
+	},
+	{
+		"url": "https://github.com/McJoppy/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/250622-mcraidy/",
+		"name": "mcraidy's Repository"
+	},
+	{
+		"url": "https://github.com/findthelorax/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/169140-findthelorax/",
+		"name": "Findthelorax's Repository"
+	},
+	{
+		"url": "https://github.com/j1philli/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/84279-j1philli/",
+		"name": "j1philli's Repository"
+	},
+	{
+		"url": "https://github.com/lucamarchiori/OwnTracksRecorderUnraid",
+		"profile": "https://forums.unraid.net/profile/255135-lucamarchiori/",
+		"name": "lucamarchiori's Repository"
+	},
+	{
+		"url": "https://github.com/jinlife/docker-templates",
+		"profile": "https://forums.unraid.net/profile/119719-jinlife/",
+		"name": "jinlife's Repository"
+	},
+	{
+		"url": "https://github.com/RealFascinated/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/87787-imfascinated/",
+		"name": "ImFascinated's Repository"
+	},
+	{
+		"url": "https://github.com/criscrafter/Unraid-CA",
+		"profile": "https://forums.unraid.net/profile/154961-criscrafter/",
+		"name": "criscrafter's Repository"
+	},
+	{
+		"url": "https://github.com/criblio/unraid",
+		"profile": "https://forums.unraid.net/profile/256028-criblio/",
+		"name": "Criblio's Repository"
+	},
+	{
+		"url": "https://github.com/W3LFARe/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/129748-welfare/",
+		"name": "welfare's Repository"
+	},
+	{
+		"url": "https://github.com/greycubesgav/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/119829-beastieg/",
+		"name": "beastieg's Repository"
+	},
+	{
+		"url": "https://github.com/vLX42/backdrop-generator",
+		"profile": "https://forums.unraid.net/profile/288463-vlx42/",
+		"name": "vlx42's Repository"
+	},
+	{
+		"url": "https://github.com/scolcipitato/plugin-repository",
+		"profile": "https://forums.unraid.net/profile/109953-scolcipitato/",
+		"name": "scolcipitato's Repository"
+	},
+	{
+		"url": "https://github.com/hoody424/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/127129-hoody424/",
+		"name": "hoody424's Repository"
+	},
+	{
+		"url": "https://github.com/skrashevich/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/198957-svk/",
+		"name": "svk's Repository"
+	},
+	{
+		"url": "https://github.com/Muxelmann/unraid-app_anaconda3",
+		"profile": "https://forums.unraid.net/profile/238596-muxelmann/",
+		"name": "muxelmann's Repository"
+	},
+	{
+		"url": "https://github.com/hudikhq/hoodik-unraid",
+		"profile": "https://forums.unraid.net/profile/228687-htunlogic/",
+		"name": "htunlogic's Repository"
+	},
+	{
+		"url": "https://github.com/edgar971/open-chat",
+		"profile": "https://forums.unraid.net/profile/238357-el_pino/",
+		"name": "el_pino's Repository"
+	},
+	{
+		"url": "https://github.com/evilalmus/UNRAID_COMMUNITY_APPS",
+		"profile": "https://forums.unraid.net/profile/178171-almus/",
+		"name": "almus' Repository"
+	},
+	{
+		"url": "https://github.com/ArabCoders/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/260951-ac-watchstate/",
+		"name": "AC-WatchState's Repository"
+	},
+	{
+		"url": "https://github.com/ImSkully/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/186901-imskully/",
+		"name": "ImSkully's Repository"
+	},
+	{
+		"url": "https://github.com/BitlessByte0/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/261347-bitlessbyte/",
+		"name": "BitlessByte's Repository"
+	},
+	{
+		"url": "https://github.com/SamTV12345/podfetch-unraid-config",
+		"profile": "https://forums.unraid.net/profile/261451-samtv12345/",
+		"name": "SamTV12345's Repository"
+	},
+	{
+		"url": "https://github.com/MattFaz/unraid_templates/",
+		"profile": "https://forums.unraid.net/profile/76145-mattfaz/",
+		"name": "MattFaz's Repository"
+	},
+	{
+		"url": "https://github.com/cloud-fs/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/261359-rotten-pagoda5238/",
+		"name": "rotten-pagoda5238's Repository"
+	},
+	{
+		"url": "https://github.com/sebastienvermeille/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/122183-sbeex/",
+		"name": "sbeex's Repository"
+	},
+	{
+		"url": "https://github.com/KodCloud-dev/unraid_template",
+		"profile": "https://forums.unraid.net/profile/255377-sealnado/",
+		"name": "sealnado's Repository"
+	},
+	{
+		"url": "https://github.com/xompage/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/262898-xompage/",
+		"name": "xompage's Repository"
+	},
+	{
+		"url": "https://github.com/EideardVMR/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/204759-eideard/",
+		"name": "Eideard's Repository"
+	},
+	{
+		"url": "https://github.com/asparon/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/96069-asparon/",
+		"name": "Asparon's Repository"
+	},
+	{
+		"url": "https://github.com/malkiebr/unraid-localtonet",
+		"profile": "https://forums.unraid.net/profile/234461-malkie/",
+		"name": "malkie's Repository"
+	},
+	{
+		"url": "https://github.com/mtrogman/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/115379-mtrogman/",
+		"name": "mtrogman's Repository"
+	},
+	{
+		"url": "https://github.com/alex-red/unraid-ca-templates",
+		"profile": "https://forums.unraid.net/profile/160581-alexred/",
+		"name": "AlexRed's Repository",
+		"duplicated": {
+			"dbgate/dbgate:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/soonic6/unraid-templates-ca",
+		"profile": "https://forums.unraid.net/profile/94002-sonic6/",
+		"name": "sonic6's Repository"
+	},
+	{
+		"url": "https://github.com/d3vyce/unraid-template",
+		"profile": "https://forums.unraid.net/profile/99205-d3vyce/",
+		"name": "d3vyce's Repository",
+		"duplicated": {
+			"lissy93/web-check": true
+		}
+	},
+	{
+		"url": "https://github.com/furritos/docker-templates",
+		"profile": "https://forums.unraid.net/profile/149001-deadfeet/",
+		"name": "DeadFeet's Repository"
+	},
+	{
+		"url": "https://github.com/alex3305/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/149439-alex3305/",
+		"name": "alex3305's Repository"
+	},
+	{
+		"url": "https://github.com/NightMeer/Unraid-Docker-Templates",
+		"profile": "https://forums.unraid.net/profile/191921-nightmeer/",
+		"name": "NightMeer's Repository"
+	},
+	{
+		"url": "https://github.com/dixtdf/templates",
+		"profile": "https://forums.unraid.net/profile/262846-dixtdf/",
+		"name": "dixtdf's Repository"
+	},
+	{
+		"url": "https://github.com/chirmstream/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/103420-dglb99/",
+		"name": "dglb99's Repository"
+	},
+	{
+		"url": "https://github.com/Phalcode/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/266495-phalcode/",
+		"name": "phalcode's Repository"
+	},
+	{
+		"url": "https://github.com/nylonee/watchlistarr-unraid",
+		"profile": "https://forums.unraid.net/profile/142159-nylonee/",
+		"name": "nylonee's Repository"
+	},
+	{
+		"url": "https://github.com/pallebone/UnifiUnraidReborn",
+		"profile": "https://forums.unraid.net/profile/100868-peteasking/",
+		"name": "PeteAsking's Repository"
+	},
+	{
+		"url": "https://github.com/EldonMcGuinness/UnraidCA",
+		"profile": "https://forums.unraid.net/profile/261788-eldonmcguinness/",
+		"name": "EldonMcGuiness' Repository"
+	},
+	{
+		"url": "https://github.com/Infotrend-Inc/OpenAI_WebUI",
+		"profile": "https://forums.unraid.net/profile/256461-iti/",
+		"name": "ITI's Repository"
+	},
+	{
+		"url": "https://github.com/BBergle/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/228849-bbergle/",
+		"name": "BBergle's Repository"
+	},
+	{
+		"url": "https://github.com/xiaodoudou/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/145775-xiaodoudou/",
+		"name": "Xiaodoudou's Repository"
+	},
+	{
+		"url": "https://github.com/PlazzmiK/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/268068-plazzmik/",
+		"name": "Plazzmik's Repository"
+	},
+	{
+		"url": "https://github.com/Core-i99/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/151311-core-i99/",
+		"name": "Core-i99's Repository"
+	},
+	{
+		"url": "https://github.com/Bobstin/willow-application-server",
+		"profile": "https://forums.unraid.net/profile/227361-bobstin/",
+		"name": "Bobstin's Repository"
+	},
+	{
+		"url": "https://github.com/ngfchl/ptools_unraid_template",
+		"profile": "https://forums.unraid.net/profile/268036-jacksonnie/",
+		"name": "JacksonNie's Repository"
+	},
+	{
+		"url": "https://github.com/Joly0/docker-templates",
+		"profile": "https://forums.unraid.net/profile/86760-joly0/",
+		"name": "joly0's Repository",
+		"duplicated": {
+			"ghcr.io/lodestone-team/lodestone_core": true
+		}
+	},
+	{
+		"url": "https://github.com/reloadfast/unraid_template_LibreLinkUp_Uploader",
+		"profile": "https://forums.unraid.net/profile/125005-guillermomg/",
+		"name": "GuillermoMG's Repository"
+	},
+	{
+		"url": "https://github.com/cross-seed/unraid-template",
+		"profile": "https://forums.unraid.net/profile/243161-ambipro/",
+		"name": "ambipro's Repository"
+	},
+	{
+		"url": "https://github.com/zakkarry/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/243161-ambipro/",
+		"name": "ambipro's Repository"
+	},
+	{
+		"url": "https://github.com/Donimax/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/266669-donimax/",
+		"name": "Donimax's Repository"
+	},
+	{
+		"url": "https://github.com/Droppisalt/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/229261-droppisalt/",
+		"name": "Droppisalt's Repository"
+	},
+	{
+		"url": "https://github.com/Infotrend-Inc/CTPO",
+		"name": "Infotrend Inc's Repository",
+		"profile": "https://forums.unraid.net/profile/256461-infotrend-inc/"
+	},
+	{
+		"url": "https://github.com/jnbarlow/unraid_templates",
+		"profile": "https://forums.unraid.net/profile/238964-john-barlow/",
+		"name": "John Barlow's Repository"
+	},
+	{
+		"url": "https://github.com/Phil-Barker/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/211519-philbarker/",
+		"name": "PhilBarker's Repository"
+	},
+	{
+		"url": "https://github.com/Eurotimmy/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/175441-eurotimmy/",
+		"name": "Eurotimmy's Repository",
+		"duplicated": {
+			"rommapp/romm:latest": true
+		}
+	},
+	{
+		"url": "https://github.com/MiranoVerhoef/Unraid-Mirano",
+		"profile": "https://forums.unraid.net/profile/96734-mirano/",
+		"name": "Mirano's Repository",
+		"duplicated": {
+			"dockurr/windows": true
+		}
+	},
+	{
+		"url": "https://github.com/bstottle/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/225-stottle/",
+		"name": "stottle's Repository"
+	},
+	{
+		"url": "https://github.com/UNRA1DUser/unraid-docker-templates",
+		"profile": "https://forums.unraid.net/profile/120631-unra1duser/",
+		"name": "UNRA1DUser's Repository",
+		"duplicated": {
+			"linuxserver/duckdns": true,
+			"jc21/nginx-proxy-manager": true,
+			"library/postgres": true,
+			"postgres": true,
+			"redis": true,
+			"tensorchord/pgvecto-rs:pg16-v0.2.1": true
+		}
+	},
+	{
+		"url": "https://github.com/0neTX/UnRAID_Template",
+		"profile": "https://forums.unraid.net/profile/161660-onetx/",
+		"name": "onetx's Repository"
+	},
+	{
+		"url": "https://github.com/disbedan015/nadekobotv4-unraid",
+		"profile": "https://forums.unraid.net/profile/115097-disbedan015/",
+		"name": "disbedan015's Repository"
+	},
+	{
+		"url": "https://github.com/ds-sebastian/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/238004-pureelectricity/",
+		"name": "pureelectricity's Repository"
+	},
+	{
+		"url": "https://github.com/nodiaque/unraid_template",
+		"profile": "https://forums.unraid.net/profile/147860-nodiaque/",
+		"name": "Nodiaque's Repository"
+	},
+	{
+		"url": "https://github.com/EMP83/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/271480-emp83/",
+		"name": "emp83's Repository",
+		"duplicated": {
+			"jc21/nginx-proxy-manager": true
+		}
+	},
+	{
+		"url": "https://github.com/mak-cs/unraid",
+		"profile": "https://forums.unraid.net/profile/269540-mak-cs/",
+		"name": "MAK-CS' Repository"
+	},
+	{
+		"url": "https://github.com/rezo552/unraid-ltfs/",
+		"profile": "https://forums.unraid.net/profile/271555-rezo552/",
+		"name": "ReZo552's Repository"
+	},
+	{
+		"url": "https://github.com/dgongut/UnRAID-Templates",
+		"profile": "https://forums.unraid.net/profile/250140-dgongut/",
+		"name": "dgongut's Repository"
+	},
+	{
+		"url": "https://github.com/jcoker85/UnraidTemplates",
+		"profile": "https://forums.unraid.net/profile/255902-jamxx/",
+		"name": "Jamxx's Repository"
+	},
+	{
+		"url": "https://github.com/Terebi42/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/252870-terebi/",
+		"name": "Terebi's Repository"
+	},
+	{
+		"url": "https://github.com/freeskier93/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/125013-dcooper/",
+		"name": "dcooper's Repository"
+	},
+	{
+		"url": "https://github.com/SasaKaranovic/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/273010-sasakaranovic/",
+		"name": "SasaKaranovic's Repository"
+	},
+	{
+		"url": "https://github.com/Lowess/docker-templates-unraid",
+		"profile": "https://forums.unraid.net/profile/161755-florian-dambrine/",
+		"name": "Florian Dambrine's Repository"
+	},
+	{
+		"url": "https://github.com/jgennari/UnraidApps",
+		"profile": "https://forums.unraid.net/profile/212091-joey-gennari/",
+		"name": "Joey Gennari's Repository"
+	},
+	{
+		"url": "https://github.com/AronMarinelli/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/126179-aronm/",
+		"name": "AronM's Repository"
+	},
+	{
+		"url": "https://github.com/kieraneglin/unraid_ca",
+		"profile": "https://forums.unraid.net/profile/185979-kieran-e/",
+		"name": "Kieran E's Repository"
+	},
+	{
+		"url": "https://github.com/tschoerk/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/273668-tschoerk/",
+		"name": "tschoerk's Repository"
+	},
+	{
+		"url": "https://github.com/fdm-monster/fdm-monster-unraid",
+		"profile": "https://forums.unraid.net/profile/124887-davidzwa/",
+		"name": "davidzwa's Repository"
+	},
+	{
+		"url": "https://github.com/NebN/unraid-apps",
+		"profile": "https://forums.unraid.net/profile/274578-nebn/",
+		"name": "NebN's Repository"
+	},
+	{
+		"url": "https://github.com/gbendy/unraid-templates",
+		"profile": "https://forums.unraid.net/profile/275025-bendy/",
+		"name": "bendy's Repository"
+	},
+	{
+		"url": "https://github.com/emaspa/emaspa-unraid-templates",
+		"profile": "https://forums.unraid.net/profile/71014-bubbl3/",
+		"name": "emaspa's Repository"
+	}
 ]


### PR DESCRIPTION
Adding my template repository for the WireView Pro II Unraid plugin.

**Template repo**: https://github.com/emaspa/emaspa-unraid-templates
**Plugin repo**: https://github.com/emaspa/wireview-hwmon-unraid
**Forum profile**: https://forums.unraid.net/profile/71014-bubbl3/

The plugin integrates the Thermal Grizzly WireView Pro II GPU power monitor into Unraid — dashboard tile with live sensor readings, full device configuration page, fault alerts, and CLI tool.

Requires Unraid 7.2.3+.